### PR TITLE
Fix plugin casing in XML description

### DIFF
--- a/pick_ik_kinematics_description.xml
+++ b/pick_ik_kinematics_description.xml
@@ -1,4 +1,4 @@
 <library path="pick_ik_plugin">
-    <class name="pick_ik/PickIkPlugin" type="pick_ik::PickIkPlugin" base_class_type="kinematics::KinematicsBase">
+    <class name="pick_ik/PickIkPlugin" type="pick_ik::PickIKPlugin" base_class_type="kinematics::KinematicsBase">
     </class>
 </library>


### PR DESCRIPTION
whoops.

This is why the plugin wouldn't load correctly in the RViz tutorials (or generally) since renaming from `gd_ik` to `pick_ik`.