### PR TITLE
Drop minimum cmake to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.16)
 project(pick_ik)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")


### PR DESCRIPTION
This is so that when we release this into ROS it'll build on the buildfarm for RHEL 8. We aren't actually using any 3.22 features so this is fine.