### PR TITLE
Expand robot tests + handle zero rotation scaling in frame tests

### DIFF
--- a/include/pick_ik/fk_moveit.hpp
+++ b/include/pick_ik/fk_moveit.hpp
@@ -13,6 +13,6 @@ using FkFn = std::function<std::vector<Eigen::Isometry3d>(std::vector<double> co
 
 auto make_fk_fn(std::shared_ptr<moveit::core::RobotModel const> robot_model,
                 moveit::core::JointModelGroup const* jmg,
-                std::vector<size_t> tip_link_indexes) -> FkFn;
+                std::vector<size_t> tip_link_indices) -> FkFn;
 
 }  // namespace pick_ik

--- a/include/pick_ik/goal.hpp
+++ b/include/pick_ik/goal.hpp
@@ -13,10 +13,13 @@
 
 namespace pick_ik {
 
+// Frame equality tests
 using FrameTestFn = std::function<bool(Eigen::Isometry3d const& tip_frame)>;
-auto make_frame_tests(std::vector<Eigen::Isometry3d> goal_frames, double twist_threshold)
-    -> std::vector<FrameTestFn>;
+auto make_frame_tests(std::vector<Eigen::Isometry3d> goal_frames,
+                      double twist_threshold,
+                      bool test_rotation = true) -> std::vector<FrameTestFn>;
 
+// Pose cost functions
 using PoseCostFn = std::function<double(std::vector<Eigen::Isometry3d> const& tip_frames)>;
 auto make_pose_cost_fn(Eigen::Isometry3d goal, size_t goal_link_index, double rotation_scale)
     -> PoseCostFn;

--- a/include/pick_ik/robot.hpp
+++ b/include/pick_ik/robot.hpp
@@ -25,19 +25,19 @@ struct Robot {
     // Create new Robot from a RobotModel
     static auto from(std::shared_ptr<moveit::core::RobotModel const> const& model,
                      moveit::core::JointModelGroup const* jmg,
-                     std::vector<size_t> tip_link_indexes) -> Robot;
+                     std::vector<size_t> tip_link_indices) -> Robot;
 };
 
-auto get_link_indexes(std::shared_ptr<moveit::core::RobotModel const> const& model,
+auto get_link_indices(std::shared_ptr<moveit::core::RobotModel const> const& model,
                       std::vector<std::string> const& names)
     -> tl::expected<std::vector<size_t>, std::string>;
 
-auto get_active_variable_indexes(std::shared_ptr<moveit::core::RobotModel const> const& robot_model,
+auto get_active_variable_indices(std::shared_ptr<moveit::core::RobotModel const> const& robot_model,
                                  moveit::core::JointModelGroup const* jmg,
-                                 std::vector<size_t> const& tip_link_indexes)
+                                 std::vector<size_t> const& tip_link_indices)
     -> std::vector<size_t>;
 
-auto get_minimal_displacement_factors(std::vector<size_t> const& active_variable_indexes,
+auto get_minimal_displacement_factors(std::vector<size_t> const& active_variable_indices,
                                       Robot const& robot) -> std::vector<double>;
 
 auto get_variables(moveit::core::RobotState const& robot_state) -> std::vector<double>;

--- a/src/fk_moveit.cpp
+++ b/src/fk_moveit.cpp
@@ -10,7 +10,7 @@ namespace pick_ik {
 
 auto make_fk_fn(std::shared_ptr<moveit::core::RobotModel const> robot_model,
                 moveit::core::JointModelGroup const* jmg,
-                std::vector<size_t> tip_link_indexes) -> FkFn {
+                std::vector<size_t> tip_link_indices) -> FkFn {
     auto robot_state = moveit::core::RobotState(robot_model);
     robot_state.setToDefaultValues();
 
@@ -22,8 +22,8 @@ auto make_fk_fn(std::shared_ptr<moveit::core::RobotModel const> robot_model,
         robot_state.updateLinkTransforms();
 
         std::vector<Eigen::Isometry3d> tip_frames;
-        std::transform(tip_link_indexes.cbegin(),
-                       tip_link_indexes.cend(),
+        std::transform(tip_link_indices.cbegin(),
+                       tip_link_indices.cend(),
                        std::back_inserter(tip_frames),
                        [&](auto index) {
                            auto const* link_model = robot_model->getLinkModel(index);

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -20,13 +20,26 @@ auto make_frame_test_fn(Eigen::Isometry3d goal_frame, double twist_threshold) ->
     };
 }
 
-auto make_frame_tests(std::vector<Eigen::Isometry3d> goal_frames, double twist_threshold)
-    -> std::vector<FrameTestFn> {
+auto make_position_test_fn(Eigen::Isometry3d goal_frame, double twist_threshold) -> FrameTestFn {
+    return [=](Eigen::Isometry3d const& tip_frame) -> bool {
+        return goal_frame.translation().isApprox(tip_frame.translation(), twist_threshold);
+    };
+}
+
+auto make_frame_tests(std::vector<Eigen::Isometry3d> goal_frames,
+                      double twist_threshold,
+                      bool test_rotation) -> std::vector<FrameTestFn> {
     auto tests = std::vector<FrameTestFn>{};
     std::transform(goal_frames.cbegin(),
                    goal_frames.cend(),
                    std::back_inserter(tests),
-                   [&](auto const& frame) { return make_frame_test_fn(frame, twist_threshold); });
+                   [&](auto const& frame) {
+                       if (test_rotation) {
+                           return make_frame_test_fn(frame, twist_threshold);
+                       } else {
+                           return make_position_test_fn(frame, twist_threshold);
+                       }
+                   });
     return tests;
 }
 

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -25,7 +25,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
 
     std::vector<std::string> joint_names_;
     std::vector<std::string> link_names_;
-    std::vector<size_t> tip_link_indexes_;
+    std::vector<size_t> tip_link_indices_;
     Robot robot_;
 
    public:
@@ -79,11 +79,11 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         link_names_ = tip_frames_;
 
         // Create our internal Robot object from the robot model
-        tip_link_indexes_ =
-            get_link_indexes(robot_model_, tip_frames_)
+        tip_link_indices_ =
+            get_link_indices(robot_model_, tip_frames_)
                 .or_else([](auto const& error) { throw std::invalid_argument(error); })
                 .value();
-        robot_ = Robot::from(robot_model_, jmg_, tip_link_indexes_);
+        robot_ = Robot::from(robot_model_, jmg_, tip_link_indices_);
 
         return true;
     }
@@ -120,7 +120,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             make_pose_cost_functions(goal_frames, params.rotation_scale);
 
         // forward kinematics function
-        auto const fk_fn = make_fk_fn(robot_model_, jmg_, tip_link_indexes_);
+        auto const fk_fn = make_fk_fn(robot_model_, jmg_, tip_link_indices_);
 
         // Create goals (weighted cost functions)
         auto goals = std::vector<Goal>{};

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -113,7 +113,9 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         }();
 
         // Test functions to determine if we are at our goal frame
-        auto const frame_tests = make_frame_tests(goal_frames, params.twist_threshold);
+        auto const test_rotation = (params.rotation_scale > 0.0);
+        auto const frame_tests =
+            make_frame_tests(goal_frames, params.twist_threshold, test_rotation);
 
         // Cost functions used for optimizing towards goal frames
         auto const pose_cost_functions =

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -147,7 +147,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         auto const solution_fn =
             make_is_solution_test_fn(frame_tests, goals, params.cost_threshold, fk_fn);
 
-        // single function used by gradient decent to calculate cost of solution
+        // single function used by gradient descent to calculate cost of solution
         auto const cost_fn = make_cost_fn(pose_cost_functions, goals, fk_fn);
 
         // search for a solution

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(Catch2 3.1.0 REQUIRED)
 
 add_executable(test-pick_ik
     goal_tests.cpp
+    ik_tests.cpp
     robot_tests.cpp
 )
 target_link_libraries(test-pick_ik

--- a/tests/goal_tests.cpp
+++ b/tests/goal_tests.cpp
@@ -8,8 +8,7 @@
 
 TEST_CASE("pick_ik::make_frame_tests") {
     auto const epsilon = 0.00001;
-    Eigen::Isometry3d const zero_frame =
-        Eigen::Translation3d(0.0, 0.0, 0.0) * Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0);
+    auto const zero_frame = Eigen::Isometry3d::Identity();
 
     SECTION("One goal, one test") {
         auto const test_fns = pick_ik::make_frame_tests({zero_frame}, epsilon);
@@ -41,11 +40,23 @@ TEST_CASE("pick_ik::make_frame_tests") {
         auto const test_fns = pick_ik::make_frame_tests({zero_frame}, epsilon);
         CHECK(test_fns.at(0)({zero_frame}) == true);
     }
+
+    SECTION("Goal is frame, but orientation is different") {
+        auto const zero_frame_rotated = Eigen::Translation3d(0.0, 0.0, 0.0) *
+                                        Eigen::AngleAxisd(M_PI_4, Eigen::Vector3d::UnitZ());
+        
+        // With rotation in frame test
+        auto const test_fns = pick_ik::make_frame_tests({zero_frame}, epsilon, true);
+        CHECK(test_fns.at(0)({zero_frame_rotated}) == false);
+
+        // Without rotation in frame test
+        auto const test_fns_pos_only = pick_ik::make_frame_tests({zero_frame}, epsilon, false);
+        CHECK(test_fns_pos_only.at(0)({zero_frame_rotated}) == true);
+    }
 }
 
 TEST_CASE("pick_ik::make_pose_cost_fn") {
-    Eigen::Isometry3d const zero_frame =
-        Eigen::Translation3d(0.0, 0.0, 0.0) * Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0);
+    auto const zero_frame = Eigen::Isometry3d::Identity();
     Eigen::Isometry3d const translate_y2_frame =
         Eigen::Translation3d(0.0, 2.0, 0.0) * Eigen::Quaterniond(1.0, 0.0, 0.0, 0.0);
     Eigen::Isometry3d const translate_xy1_frame =

--- a/tests/goal_tests.cpp
+++ b/tests/goal_tests.cpp
@@ -44,7 +44,7 @@ TEST_CASE("pick_ik::make_frame_tests") {
     SECTION("Goal is frame, but orientation is different") {
         auto const zero_frame_rotated = Eigen::Translation3d(0.0, 0.0, 0.0) *
                                         Eigen::AngleAxisd(M_PI_4, Eigen::Vector3d::UnitZ());
-        
+
         // With rotation in frame test
         auto const test_fns = pick_ik::make_frame_tests({zero_frame}, epsilon, true);
         CHECK(test_fns.at(0)({zero_frame_rotated}) == false);

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -48,31 +48,31 @@ auto make_rr_model_for_ik() {
     return builder.build();
 }
 
-// TEST_CASE("RR model FK") {
-//     auto const robot_model = make_rr_model_for_ik();
+TEST_CASE("RR model FK") {
+    auto const robot_model = make_rr_model_for_ik();
 
-//     auto const jmg = robot_model->getJointModelGroup("group");
-//     auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"ee"}).value();
+    auto const jmg = robot_model->getJointModelGroup("group");
+    auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"ee"}).value();
 
-//     auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
+    auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
 
-//     SECTION("Zero joint position") {
-//         std::vector<double> const joint_vals = {0.0, 0.0};
-//         auto const result = fk_fn(joint_vals);
-//         CHECK(result[0].translation().x() == Catch::Approx(3.0));
-//         CHECK(result[0].translation().y() == Catch::Approx(0.0));
-//     }
+    SECTION("Zero joint position") {
+        std::vector<double> const joint_vals = {0.0, 0.0};
+        auto const result = fk_fn(joint_vals);
+        CHECK(result[0].translation().x() == Catch::Approx(3.0));
+        CHECK(result[0].translation().y() == Catch::Approx(0.0));
+    }
 
-//     SECTION("Non-zero joint position") {
-//         std::vector<double> const joint_vals = {M_PI_4, -M_PI_4};
-//         auto const expected_x = 2.0 * std::cos(M_PI_4) + 1.0;
-//         auto const expected_y = 2.0 * std::sin(M_PI_4);
+    SECTION("Non-zero joint position") {
+        std::vector<double> const joint_vals = {M_PI_4, -M_PI_4};
+        auto const expected_x = 2.0 * std::cos(M_PI_4) + 1.0;
+        auto const expected_y = 2.0 * std::sin(M_PI_4);
 
-//         auto const result = fk_fn(joint_vals);
-//         CHECK(result[0].translation().x() == Catch::Approx(expected_x).margin(0.001));
-//         CHECK(result[0].translation().y() == Catch::Approx(expected_y).margin(0.001));
-//     }
-// }
+        auto const result = fk_fn(joint_vals);
+        CHECK(result[0].translation().x() == Catch::Approx(expected_x).margin(0.001));
+        CHECK(result[0].translation().y() == Catch::Approx(expected_y).margin(0.001));
+    }
+}
 
 // Helper param struct and function to test IK solution.
 struct IkTestParams {

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -1,0 +1,127 @@
+#include <pick_ik/fk_moveit.hpp>
+#include <pick_ik/goal.hpp>
+#include <pick_ik/ik_gradient.hpp>
+#include <pick_ik/robot.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <Eigen/Geometry>
+#include <iostream>
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/utils/robot_model_test_utils.h>
+
+auto make_rr_model_for_ik() {
+    /**
+     * We aim to make an RR robot like this:
+     *
+     *  revolute_2 -->  (b) ==== |E  <-- ee
+     *                 //
+     *                //
+     *               (a)  <-- revolute_1
+     *             origin
+     **/
+    auto builder = moveit::core::RobotModelBuilder("rr", "base");
+
+    // Define transforms and joint axes
+    geometry_msgs::msg::Pose origin;
+    origin.orientation.w = 1.0;
+
+    geometry_msgs::msg::Pose tform_x1;
+    tform_x1.position.x = 1.0;  // This is the length of each link.
+    tform_x1.orientation.w = 1.0;
+
+    auto const z_axis = urdf::Vector3(0, 0, 1);
+
+    // Build the actual robot chain.
+    builder.addChain("base->a", "revolute", {origin}, z_axis);
+    builder.addChain("a->b", "revolute", {tform_x1}, z_axis);
+    builder.addChain("b->ee", "fixed", {tform_x1});
+    builder.addGroupChain("base", "ee", "group");
+    CHECK(builder.isValid());
+    return builder.build();
+}
+
+TEST_CASE("RR model FK") {
+    auto const robot_model = make_rr_model_for_ik();
+
+    auto const jmg = robot_model->getJointModelGroup("group");
+    auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"ee"}).value();
+
+    auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
+
+    SECTION("Zero joint position") {
+        std::vector<double> const joint_vals = {0.0, 0.0};
+        auto const result = fk_fn(joint_vals);
+        CHECK(result[0].translation().x() == Catch::Approx(2.0));
+        CHECK(result[0].translation().y() == Catch::Approx(0.0));
+    }
+
+    SECTION("Non-zero joint position") {
+        auto constexpr PI_4 = 0.78539816339;
+        std::vector<double> const joint_vals = {PI_4, -PI_4};
+        auto const result = fk_fn(joint_vals);
+        CHECK(result[0].translation().x() == Catch::Approx(1.707).margin(0.001));
+        CHECK(result[0].translation().y() == Catch::Approx(0.707).margin(0.001));
+    }
+}
+
+TEST_CASE("RR model IK") {
+    auto const robot_model = make_rr_model_for_ik();
+    auto const jmg = robot_model->getJointModelGroup("group");
+    auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"ee"}).value();
+    auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
+
+    SECTION("Pose goal only") {
+        // Define goal frame and expected joint values.
+        Eigen::Isometry3d const goal_frame =
+            Eigen::Translation3d(2.0, 0.0, 0.0) * Eigen::AngleAxisd(0.0, Eigen::Vector3d::UnitZ());
+        const std::vector<double> expected_joint_angles = {0.0, 0.0};
+
+        // Make solution function
+        auto const twist_threshold = 0.001;
+        auto const frame_tests = pick_ik::make_frame_tests({goal_frame}, twist_threshold);
+        CHECK(frame_tests.size() == 1);
+
+        auto const cost_function = kinematics::KinematicsBase::IKCostFn();  // TODO
+
+        geometry_msgs::msg::Pose ik_pose;
+        ik_pose.position.x = 2.0;
+        ik_pose.orientation.w = 1.0;
+
+        auto const ik_seed_state = {0.1, -0.1};  // Initial guess
+        auto const cost_threshold = 0.001;
+        std::vector<pick_ik::Goal> goals = {};
+
+        auto const solution_fn =
+            pick_ik::make_is_solution_test_fn(frame_tests, goals, cost_threshold, fk_fn);
+
+        CHECK(solution_fn({0.0, 0.0}) == true);  // Exact match (within floating point tolerance)
+        CHECK(solution_fn({0.0001, -0.0001}) == true);  // Match within threshold
+        CHECK(solution_fn({0.01, -0.01}) == false);     // Match outside threshold
+        CHECK(solution_fn({1.5707, 0.0}) == false);     // Not a match
+
+        // Make pose cost function
+        auto const rotation_scale = 0.5;
+        auto const pose_cost_functions =
+            pick_ik::make_pose_cost_functions({goal_frame}, rotation_scale);
+        CHECK(pose_cost_functions.size() == 1);
+
+        // Solve IK
+        auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
+        auto const cost_fn = pick_ik::make_cost_fn(pose_cost_functions, goals, fk_fn);
+
+        auto const timeout = 10.0;
+        auto const return_approx_solution = false;
+        auto const maybe_solution = pick_ik::ik_search(ik_seed_state,
+                                                       robot,
+                                                       cost_fn,
+                                                       solution_fn,
+                                                       timeout,
+                                                       return_approx_solution);
+        CHECK(maybe_solution);
+        CHECK(maybe_solution.value()[0] == Catch::Approx(expected_joint_angles[0]).margin(0.01));
+        CHECK(maybe_solution.value()[1] == Catch::Approx(expected_joint_angles[1]).margin(0.01));
+    }
+}

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -249,7 +249,7 @@ TEST_CASE("Panda model IK") {
                                                   params);
 
         REQUIRE(maybe_solution.has_value());
-        for (size_t i=0; i<7; ++i) {
+        for (size_t i = 0; i < 7; ++i) {
             CHECK(maybe_solution.value()[i] == Catch::Approx(home_joint_angles[i]).margin(0.01));
         }
     }
@@ -271,7 +271,7 @@ TEST_CASE("Panda model IK") {
                                                   params);
 
         REQUIRE(maybe_solution.has_value());
-        for (size_t i=0; i<7; ++i) {
+        for (size_t i = 0; i < 7; ++i) {
             // NOTE the extra tolerance...
             CHECK(maybe_solution.value()[i] == Catch::Approx(actual_joint_angles[i]).margin(0.025));
         }

--- a/tests/robot_tests.cpp
+++ b/tests/robot_tests.cpp
@@ -7,54 +7,89 @@
 #include <moveit/utils/robot_model_test_utils.h>
 
 auto make_rr_model() {
+    /**
+     * We aim to make an RR robot like this:
+     *
+     *  revolute_2 -->  (b) ==== |E  <-- ee
+     *                 //
+     *                //
+     *               (a)  <-- revolute_1
+     *             origin
+     **/
     auto builder = moveit::core::RobotModelBuilder("rr", "base");
+
+    // Define transforms and joint axes
     geometry_msgs::msg::Pose origin;
-    origin.position.x = 1;
-    origin.orientation.w = 1;
-    builder.addChain("base->a", "revolute", {origin}, urdf::Vector3(1, 0, 0));
-    builder.addChain("a->b", "revolute", {origin}, urdf::Vector3(1, 0, 0));
-    builder.addGroupChain("base", "b", "group");
+    origin.orientation.w = 1.0;
+
+    geometry_msgs::msg::Pose tform_x1;
+    tform_x1.position.x = 1.0;  // This is the length of each link.
+    tform_x1.orientation.w = 1.0;
+
+    auto const z_axis = urdf::Vector3(0, 0, 1);
+
+    // Build the actual robot chain.
+    builder.addChain("base->a", "revolute", {origin}, z_axis);
+    builder.addChain("a->b", "revolute", {tform_x1}, z_axis);
+    builder.addChain("b->ee", "fixed", {tform_x1});
+    builder.addGroupChain("base", "ee", "group");
     CHECK(builder.isValid());
     return builder.build();
 }
 
-TEST_CASE("pick_ik::get_link_indexes") {
+TEST_CASE("pick_ik::get_link_indices") {
     auto const robot_model = make_rr_model();
 
-    SECTION("tip joint") {
-        auto const tip_link_indexes = pick_ik::get_link_indexes(robot_model, {"b"});
-        REQUIRE(tip_link_indexes.has_value());
-        CHECK(tip_link_indexes->size() == 1);
-        CHECK(tip_link_indexes->at(0) == 2);
+    SECTION("second link") {
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"b"});
+        REQUIRE(tip_link_indices.has_value());
+        CHECK(tip_link_indices->size() == 1);
+        CHECK(tip_link_indices->at(0) == 2);
+    }
+
+    SECTION("end effector link") {
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"ee"});
+        REQUIRE(tip_link_indices.has_value());
+        CHECK(tip_link_indices->size() == 1);
+        CHECK(tip_link_indices->at(0) == 3);
+    }
+
+    SECTION("multiple links") {
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"a", "b", "ee"});
+        REQUIRE(tip_link_indices.has_value());
+        CHECK(tip_link_indices->size() == 3);
+        CHECK(tip_link_indices->at(0) == 1);
+        CHECK(tip_link_indices->at(1) == 2);
+        CHECK(tip_link_indices->at(2) == 3);
     }
 
     SECTION("no joints") {
-        auto const tip_link_indexes = pick_ik::get_link_indexes(robot_model, {});
-        REQUIRE(tip_link_indexes.has_value());
-        CHECK(tip_link_indexes->size() == 0);
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {});
+        REQUIRE(tip_link_indices.has_value());
+        CHECK(tip_link_indices->size() == 0);
     }
 
     SECTION("invalid joint") {
-        auto const tip_link_indexes = pick_ik::get_link_indexes(robot_model, {"c"});
-        REQUIRE(tip_link_indexes.has_value() == false);
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"c"});
+        REQUIRE(tip_link_indices.has_value() == false);
     }
 
     SECTION("base joint") {
-        auto const tip_link_indexes = pick_ik::get_link_indexes(robot_model, {"base"});
-        REQUIRE(tip_link_indexes.has_value());
-        CHECK(tip_link_indexes->size() == 1);
-        CHECK(tip_link_indexes->at(0) == 0);
+        auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"base"});
+        REQUIRE(tip_link_indices.has_value());
+        CHECK(tip_link_indices->size() == 1);
+        CHECK(tip_link_indices->at(0) == 0);
     }
 }
 
 TEST_CASE("pick_ik::Robot::from") {
     auto const robot_model = make_rr_model();
     auto* const jmg = robot_model->getJointModelGroup("group");
-    auto const tip_link_indexes =
-        pick_ik::get_link_indexes(robot_model, {"b"})
+    auto const tip_link_indices =
+        pick_ik::get_link_indices(robot_model, {"ee"})
             .or_else([](auto const& error) { throw std::invalid_argument(error); })
             .value();
-    auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indexes);
+    auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
 
-    SECTION("rr has two joints") { CHECK(robot.variables.size() == 2); }
+    SECTION("RR robot has two joints") { CHECK(robot.variables.size() == 2); }
 }

--- a/tests/robot_tests.cpp
+++ b/tests/robot_tests.cpp
@@ -82,7 +82,7 @@ TEST_CASE("pick_ik::get_link_indices") {
     }
 }
 
-TEST_CASE("pick_ik::Robot::from") {
+TEST_CASE("pick_ik::Robot::from -- Simple RR Model") {
     auto const robot_model = make_rr_model();
     auto* const jmg = robot_model->getJointModelGroup("group");
     auto const tip_link_indices =
@@ -92,4 +92,17 @@ TEST_CASE("pick_ik::Robot::from") {
     auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
 
     SECTION("RR robot has two joints") { CHECK(robot.variables.size() == 2); }
+}
+
+TEST_CASE("pick_ik::Robot::from -- Panda Model") {
+    using moveit::core::loadTestingRobotModel;
+    auto const robot_model = loadTestingRobotModel("panda");
+    auto* const jmg = robot_model->getJointModelGroup("panda_arm");
+    auto const tip_link_indices =
+        pick_ik::get_link_indices(robot_model, {"panda_hand"})
+            .or_else([](auto const& error) { throw std::invalid_argument(error); })
+            .value();
+    auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
+
+    SECTION("Panda has seven joints") { CHECK(robot.variables.size() == 7); }
 }


### PR DESCRIPTION
Added more test cases, specifically IK tests for a dummy RR robot and for the Panda... though the Panda IK doesn't work very well outside of small perturbations, I'm deferring that to another PR.

I also handled the case where we specify `rotation_scale = 0` so that our frame equality tests are only checking position. This should let us solve position-only IK when this is specified.