### PR TITLE
Memetic solver port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(moveit_core REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(range-v3 REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rsl REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_kdl REQUIRED)
 find_package(tl_expected REQUIRED)
@@ -41,6 +42,7 @@ target_link_libraries(pick_ik_plugin
     tf2_geometry_msgs::tf2_geometry_msgs
     tf2_kdl::tf2_kdl
     tl_expected::tl_expected
+    rsl::rsl
   PRIVATE
     fmt::fmt
     pick_ik_parameters
@@ -80,6 +82,7 @@ ament_export_dependencies(
   pluginlib
   range-v3
   rclcpp
+  rsl
   tf2_geometry_msgs
   tf2_kdl
   tl_expected

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(pick_ik_plugin SHARED
   src/forward_kinematics.cpp
   src/pick_ik_plugin.cpp
   src/goal.cpp
+  src/ik_memetic.cpp
   src/ik_gradient.cpp
   src/robot.cpp
 )

--- a/include/pick_ik/ik_gradient.hpp
+++ b/include/pick_ik/ik_gradient.hpp
@@ -22,13 +22,15 @@ struct GradientIk {
     static GradientIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
 };
 
-auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn) -> bool;
+auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double step_size = 0.0001)
+    -> bool;
 
-auto ik_search(std::vector<double> const& initial_guess,
-               Robot const& robot,
-               CostFn const& cost_fn,
-               SolutionTestFn const& solution_fn,
-               double timeout,
-               bool approx_solution) -> std::optional<std::vector<double>>;
+auto ik_gradient(std::vector<double> const& initial_guess,
+                 Robot const& robot,
+                 CostFn const& cost_fn,
+                 SolutionTestFn const& solution_fn,
+                 double timeout,
+                 bool approx_solution,
+                 double step_size = 0.0001) -> std::optional<std::vector<double>>;
 
 }  // namespace pick_ik

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -8,7 +8,7 @@
 #include <moveit/robot_model/joint_model_group.h>
 #include <moveit/robot_model/robot_model.h>
 #include <optional>
-#include <random>
+#include <rsl/random.hpp>
 #include <vector>
 
 namespace pick_ik {
@@ -43,12 +43,6 @@ class MemeticIk {
 
     // Extinction coefficient gradings (cached since they do not change).
     std::vector<double> extinction_grading_;
-
-    // RNG (TODO use RSL)
-    std::random_device rd_;
-    std::mt19937 gen_;
-    std::uniform_real_distribution<double> mutate_dist_{-0.5, 0.5};
-    std::uniform_real_distribution<double> uniform_dist_{0.0, 1.0};
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost, MemeticIkParams const& params);

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -22,10 +22,12 @@ struct Individual {
 
 class MemeticIk {
    private:
-    std::vector<double> best_;
-    double cost_;
     std::vector<Individual> population_;
-    std::vector<Individual> children_;
+
+    std::vector<double> best_;
+    double best_cost_;
+    std::vector<double> best_curr_;
+    double best_cost_curr_;
 
     // Config params
     size_t elite_count_ = 4;
@@ -39,11 +41,12 @@ class MemeticIk {
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost)
-        : best_{initial_guess}, cost_{cost}, gen_{rd_()} {};
+        : best_{initial_guess}, best_cost_{cost}, gen_{rd_()} {};
     static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
 
     std::vector<double> best() const { return best_; };
-    double bestCost() const { return cost_; };
+    double bestCost() const { return best_cost_; };
+    double bestCurrentCost() const { return best_cost_curr_; };
     size_t eliteCount() const { return elite_count_; };
     void computeExtinctions();
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -23,14 +23,17 @@ class MemeticIk {
     std::vector<double> best_;
     double cost_;
     std::vector<Individual> population_;
+    std::vector<Individual> children_;
 
     // Config params
-    size_t elite_count_ = 2;
+    size_t elite_count_ = 4;
+    size_t population_count_ = 16;
 
     // RNG (TODO move out of here)
     std::random_device rd_;
     std::mt19937 gen_;
-    std::uniform_real_distribution<double> dist_{-M_PI_4, M_PI_4};  // TODO Configure
+    std::uniform_real_distribution<double> mutate_dist_{-0.2, 0.2};
+    std::uniform_real_distribution<double> mix_dist_{0.0, 1.0};
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost)
@@ -38,18 +41,16 @@ class MemeticIk {
     static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
 
     std::vector<double> best() { return best_; };
+    size_t eliteCount() const { return elite_count_; };
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
-    void initPopulation(size_t const& population_size,
-                        Robot const& robot,
+    void initPopulation(Robot const& robot,
                         CostFn const& cost_fn,
                         std::vector<double> const& initial_guess);
-    size_t populationSize() const;
+    void reproduce(Robot const& robot, CostFn const& cost_fn);
+    size_t populationCount() const { return population_count_; };
     void printPopulation() const;
     void sortPopulation();
-    void selectPopulation(Robot const& robot, CostFn const& cost_fn);
 };
-
-// auto step(MemeticIk& self, Robot const& robot, CostFn const& cost_fn) -> bool;
 
 auto ik_memetic(std::vector<double> const& initial_guess,
                 Robot const& robot,

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -20,41 +20,52 @@ struct Individual {
     std::vector<double> gradient;
 };
 
+struct MemeticIkParams {
+    // Evolutionary algorithm parameters
+    size_t elite_size = 4;                 // Number of "keep alive" population members.
+    size_t population_size = 16;           // Number of total population members.
+    double wipeout_fitness_tol = 0.00001;  // Min fitness must improve by at least this much or the
+                                           // population is reinitialized.
+
+    // Gradient descent parameters
+    double local_step_size = 0.0001;  // Joint angle numerical perturbation step size.
+    int local_max_iters = 25;         // Max iterations per memetic exploitation step.
+    double local_max_time = 0.005;    // Max wall time per memetic exploitation step, in seconds.
+};
+
 class MemeticIk {
    private:
     std::vector<Individual> population_;
+    Individual best_;       // Best solution overall.
+    Individual best_curr_;  // Best solution so far.
 
-    std::vector<double> best_;
-    double best_cost_;
-    std::vector<double> best_curr_;
-    double best_cost_curr_;
+    MemeticIkParams params_;
 
-    // Config params
-    size_t elite_count_ = 4;
-    size_t population_count_ = 16;
+    // Extinction coefficient gradings (cached since they do not change).
+    std::vector<double> extinction_grading_;
 
-    // RNG (TODO move out of here)
+    // RNG (TODO use RSL)
     std::random_device rd_;
     std::mt19937 gen_;
     std::uniform_real_distribution<double> mutate_dist_{-0.5, 0.5};
     std::uniform_real_distribution<double> uniform_dist_{0.0, 1.0};
 
    public:
-    MemeticIk(std::vector<double> const& initial_guess, double cost)
-        : best_{initial_guess}, best_cost_{cost}, gen_{rd_()} {};
-    static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
+    MemeticIk(std::vector<double> const& initial_guess, double cost, MemeticIkParams const& params);
+    static MemeticIk from(std::vector<double> const& initial_guess,
+                          CostFn const& cost_fn,
+                          MemeticIkParams const& params);
 
-    std::vector<double> best() const { return best_; };
-    double bestCost() const { return best_cost_; };
-    double bestCurrentCost() const { return best_cost_curr_; };
-    size_t eliteCount() const { return elite_count_; };
+    Individual best() const { return best_; };
+    Individual bestCurrent() const { return best_curr_; };
+    size_t eliteCount() const { return params_.elite_size; };
     void computeExtinctions();
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
     void initPopulation(Robot const& robot,
                         CostFn const& cost_fn,
                         std::vector<double> const& initial_guess);
     void reproduce(Robot const& robot, CostFn const& cost_fn);
-    size_t populationCount() const { return population_count_; };
+    size_t populationCount() const { return params_.population_size; };
     void printPopulation() const;
     void sortPopulation();
 };
@@ -63,6 +74,7 @@ auto ik_memetic(std::vector<double> const& initial_guess,
                 Robot const& robot,
                 CostFn const& cost_fn,
                 SolutionTestFn const& solution_fn,
+                MemeticIkParams const& params,
                 double const timeout = 1.0,
                 bool const approx_solution = false,
                 bool const print_debug = false) -> std::optional<std::vector<double>>;

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -17,6 +17,7 @@ struct Individual {
     std::vector<double> genes;  // Joint angles
     double fitness;
     double extinction;
+    std::vector<double> gradient;
 };
 
 class MemeticIk {
@@ -58,7 +59,7 @@ auto ik_memetic(std::vector<double> const& initial_guess,
                 Robot const& robot,
                 CostFn const& cost_fn,
                 SolutionTestFn const& solution_fn,
-                double timeout = 10.0,
+                double timeout = 1.0,
                 bool approx_solution = false) -> std::optional<std::vector<double>>;
 
 }  // namespace pick_ik

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <pick_ik/goal.hpp>
+#include <pick_ik/robot.hpp>
+
+#include <chrono>
+#include <memory>
+#include <moveit/robot_model/joint_model_group.h>
+#include <moveit/robot_model/robot_model.h>
+#include <optional>
+#include <vector>
+
+namespace pick_ik {
+
+struct MemeticIk {
+    std::vector<double> best;
+    double cost;
+
+    static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
+};
+
+// auto step(MemeticIk& self, Robot const& robot, CostFn const& cost_fn) -> bool;
+
+auto ik_memetic(std::vector<double> const& initial_guess,
+                Robot const& robot,
+                CostFn const& cost_fn,
+                SolutionTestFn const& solution_fn,
+                double timeout = 10.0,
+                bool approx_solution = false) -> std::optional<std::vector<double>>;
+
+}  // namespace pick_ik

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -30,7 +30,7 @@ class MemeticIk {
     // RNG (TODO move out of here)
     std::random_device rd_;
     std::mt19937 gen_;
-    std::uniform_real_distribution<double> dist_{-0.5, 0.5};
+    std::uniform_real_distribution<double> dist_{-M_PI_4, M_PI_4};  // TODO Configure
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost)
@@ -40,12 +40,13 @@ class MemeticIk {
     std::vector<double> best() { return best_; };
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
     void initPopulation(size_t const& population_size,
+                        Robot const& robot,
                         CostFn const& cost_fn,
                         std::vector<double> const& initial_guess);
     size_t populationSize() const;
     void printPopulation() const;
     void sortPopulation();
-    void selectPopulation(CostFn const& cost_fn);
+    void selectPopulation(Robot const& robot, CostFn const& cost_fn);
 };
 
 // auto step(MemeticIk& self, Robot const& robot, CostFn const& cost_fn) -> bool;

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -3,12 +3,13 @@
 #include <pick_ik/goal.hpp>
 #include <pick_ik/robot.hpp>
 
+#include <rsl/random.hpp>
+
 #include <chrono>
 #include <memory>
 #include <moveit/robot_model/joint_model_group.h>
 #include <moveit/robot_model/robot_model.h>
 #include <optional>
-#include <rsl/random.hpp>
 #include <vector>
 
 namespace pick_ik {
@@ -35,14 +36,19 @@ struct MemeticIkParams {
 
 class MemeticIk {
    private:
+    // Evolutionary algorithm values
     std::vector<Individual> population_;
+    std::vector<Individual*> mating_pool_;
     Individual best_;       // Best solution overall.
     Individual best_curr_;  // Best solution so far.
+    std::optional<double> previous_fitness_;
 
+    // Solver parameters
     MemeticIkParams params_;
 
-    // Extinction coefficient gradings (cached since they do not change).
+    // Scaling coefficients (cached since they do not change).
     std::vector<double> extinction_grading_;
+    double inverse_gene_size_;
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost, MemeticIkParams const& params);
@@ -53,6 +59,7 @@ class MemeticIk {
     Individual best() const { return best_; };
     Individual bestCurrent() const { return best_curr_; };
     size_t eliteCount() const { return params_.elite_size; };
+    bool checkWipeout();
     void computeExtinctions();
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
     void initPopulation(Robot const& robot,

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -16,6 +16,7 @@ namespace pick_ik {
 struct Individual {
     std::vector<double> genes;  // Joint angles
     double fitness;
+    double extinction;
 };
 
 class MemeticIk {
@@ -32,8 +33,8 @@ class MemeticIk {
     // RNG (TODO move out of here)
     std::random_device rd_;
     std::mt19937 gen_;
-    std::uniform_real_distribution<double> mutate_dist_{-0.2, 0.2};
-    std::uniform_real_distribution<double> mix_dist_{0.0, 1.0};
+    std::uniform_real_distribution<double> mutate_dist_{-0.5, 0.5};
+    std::uniform_real_distribution<double> uniform_dist_{0.0, 1.0};
 
    public:
     MemeticIk(std::vector<double> const& initial_guess, double cost)
@@ -42,6 +43,7 @@ class MemeticIk {
 
     std::vector<double> best() { return best_; };
     size_t eliteCount() const { return elite_count_; };
+    void computeExtinctions();
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
     void initPopulation(Robot const& robot,
                         CostFn const& cost_fn,

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -42,7 +42,8 @@ class MemeticIk {
         : best_{initial_guess}, cost_{cost}, gen_{rd_()} {};
     static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
 
-    std::vector<double> best() { return best_; };
+    std::vector<double> best() const { return best_; };
+    double bestCost() const { return cost_; };
     size_t eliteCount() const { return elite_count_; };
     void computeExtinctions();
     void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -8,15 +8,44 @@
 #include <moveit/robot_model/joint_model_group.h>
 #include <moveit/robot_model/robot_model.h>
 #include <optional>
+#include <random>
 #include <vector>
 
 namespace pick_ik {
 
-struct MemeticIk {
-    std::vector<double> best;
-    double cost;
+struct Individual {
+    std::vector<double> genes;  // Joint angles
+    double fitness;
+};
 
+class MemeticIk {
+   private:
+    std::vector<double> best_;
+    double cost_;
+    std::vector<Individual> population_;
+
+    // Config params
+    size_t elite_count_ = 2;
+
+    // RNG (TODO move out of here)
+    std::random_device rd_;
+    std::mt19937 gen_;
+    std::uniform_real_distribution<double> dist_{-0.5, 0.5};
+
+   public:
+    MemeticIk(std::vector<double> const& initial_guess, double cost)
+        : best_{initial_guess}, cost_{cost}, gen_{rd_()} {};
     static MemeticIk from(std::vector<double> const& initial_guess, CostFn const& cost_fn);
+
+    std::vector<double> best() { return best_; };
+    void gradientDescent(size_t const i, Robot const& robot, CostFn const& cost_fn);
+    void initPopulation(size_t const& population_size,
+                        CostFn const& cost_fn,
+                        std::vector<double> const& initial_guess);
+    size_t populationSize() const;
+    void printPopulation() const;
+    void sortPopulation();
+    void selectPopulation(CostFn const& cost_fn);
 };
 
 // auto step(MemeticIk& self, Robot const& robot, CostFn const& cost_fn) -> bool;

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -60,7 +60,8 @@ auto ik_memetic(std::vector<double> const& initial_guess,
                 Robot const& robot,
                 CostFn const& cost_fn,
                 SolutionTestFn const& solution_fn,
-                double timeout = 1.0,
-                bool approx_solution = false) -> std::optional<std::vector<double>>;
+                double const timeout = 1.0,
+                bool const approx_solution = false,
+                bool const print_debug = false) -> std::optional<std::vector<double>>;
 
 }  // namespace pick_ik

--- a/package.xml
+++ b/package.xml
@@ -16,6 +16,7 @@
   <depend>pluginlib</depend>
   <depend>range-v3</depend>
   <depend>rclcpp</depend>
+  <depend>rsl</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_kdl</depend>
   <depend>tl_expected</depend>

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -50,8 +50,9 @@ auto make_pose_cost_fn(Eigen::Isometry3d goal, size_t goal_link_index, double ro
         return [=](std::vector<Eigen::Isometry3d> const& tip_frames) -> double {
             auto const& frame = tip_frames[goal_link_index];
             auto const q_frame = Eigen::Quaterniond(frame.rotation());
+            auto const q_dot_product = std::clamp(q_goal.dot(q_frame), -1.0, 1.0);
             return (goal.translation() - frame.translation()).squaredNorm() +
-                   std::pow(2.0 * std::acos(q_goal.dot(q_frame)) * rotation_scale, 2);
+                   std::pow(2.0 * std::acos(q_dot_product) * rotation_scale, 2);
         };
     }
     return [=](std::vector<Eigen::Isometry3d> const& tip_frames) -> double {

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -1,0 +1,99 @@
+#include <pick_ik/goal.hpp>
+#include <pick_ik/ik_gradient.hpp>
+#include <pick_ik/ik_memetic.hpp>
+#include <pick_ik/robot.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <optional>
+#include <random>
+#include <vector>
+
+namespace pick_ik {
+
+MemeticIk MemeticIk::from(std::vector<double> const& initial_guess, CostFn const& cost_fn) {
+    return MemeticIk{std::vector<double>(initial_guess.size(), 0.0), cost_fn(initial_guess)};
+}
+
+auto ik_memetic(std::vector<double> const& initial_guess,
+                Robot const& robot,
+                CostFn const& cost_fn,
+                SolutionTestFn const& solution_fn,
+                double timeout,
+                bool approx_solution) -> std::optional<std::vector<double>> {
+    if (solution_fn(initial_guess)) {
+        return initial_guess;
+    }
+
+    assert(robot.variables.size() == initial_guess.size());
+    auto ik = MemeticIk::from(initial_guess, cost_fn);
+
+    size_t constexpr population_size = 8;  // Placeholder
+    // Randomize a population.
+    std::vector<std::vector<double>> population;
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<double> dis(-0.5, 0.5);
+    population.reserve(population_size);
+    for (size_t i = 0; i < population_size; ++i) {
+        auto genotype = initial_guess;
+        if (i > 0) {
+            for (auto& val : genotype) {
+                val += dis(gen);
+            }
+        }
+        population.emplace_back(genotype);
+    }
+
+    // Initialize fitness values.
+    int iter = 0;
+    auto fitnesses = std::vector<double>(population.size(), 0.0);
+
+    auto const timeout_point =
+        std::chrono::system_clock::now() + std::chrono::duration<double>(timeout);
+    while (std::chrono::system_clock::now() < timeout_point) {
+        // Evaluate fitnesses
+        std::cout << "Iteration " << iter << " Fitnesses: " << std::endl;
+        for (size_t i = 0; i < population_size; ++i) {
+
+            // Local gradient descent
+            auto local_ik = GradientIk::from(population[i], cost_fn);
+            auto constexpr timeout_local = 0.1;
+            auto const timeout_point_local =
+                std::chrono::system_clock::now() + std::chrono::duration<double>(timeout_local);
+            while (std::chrono::system_clock::now() < timeout_point_local) {
+                step(local_ik, robot, cost_fn);
+            }    
+            population[i] = local_ik.best;
+
+            fitnesses[i] = cost_fn(population[i]);
+            std::cout << i << ": " << fitnesses[i] << " " << std::endl;
+        }
+        std::cout << std::endl;
+
+        // Sort fitnesses
+        for (size_t i = 0; i < population_size; ++i) {
+            if (solution_fn(population[i])) {
+                return population[i];
+            }
+        }
+
+        // Perturb if no solution found
+        for (auto& genotype : population) {
+            for (auto& val : genotype) {
+                val += dis(gen);
+            }
+        }
+
+        iter++;
+    }
+
+    if (approx_solution) {
+        return population[0];
+    }
+
+    return std::nullopt;
+}
+
+}  // namespace pick_ik

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -209,11 +209,10 @@ auto ik_memetic(std::vector<double> const& initial_guess,
         // Handle wipeouts if no progress is being made.
         auto constexpr improve_tol = 0.00001;  // TODO Promote
         if (previous_fitness.has_value()) {
-            #pragma GCC diagnostic push
-            #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-            bool const improved =
-                (ik.bestCurrentCost() < *previous_fitness - improve_tol);
-            #pragma GCC diagnostic pop
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+            bool const improved = (ik.bestCurrentCost() < *previous_fitness - improve_tol);
+#pragma GCC diagnostic pop
             if (!improved) {
                 if (print_debug) fmt::print("Population wipeout");
                 ik.initPopulation(robot, cost_fn, initial_guess);

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -25,13 +25,34 @@ MemeticIk::MemeticIk(std::vector<double> const& initial_guess,
     best_ = Individual{initial_guess, cost, 0.0, std::vector<double>(initial_guess.size(), 0.0)};
     best_curr_ = best_;
 
-    // Cache extinction grading coefficients to not have to recompute all the time.
+    population_.reserve(params.population_size);
+    mating_pool_.reserve(params.elite_size);
+
+    // Cache some coefficients to not have to recompute them all the time.
     extinction_grading_.reserve(params.population_size);
     for (size_t i = 0; i < params.population_size; ++i) {
         extinction_grading_.push_back(static_cast<double>(i) /
                                       static_cast<double>(params.population_size - 1));
     }
+    inverse_gene_size_ = 1.0 / static_cast<double>(initial_guess.size());
 };
+
+bool MemeticIk::checkWipeout() {
+    // Handle wipeouts if no progress is being made.
+    if (previous_fitness_.has_value()) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+        bool const improved =
+            (best_curr_.fitness < *previous_fitness_ - params_.wipeout_fitness_tol);
+#pragma GCC diagnostic pop
+        if (!improved) {
+            return true;
+        }
+    }
+
+    previous_fitness_ = best_curr_.fitness;
+    return false;
+}
 
 void MemeticIk::computeExtinctions() {
     double min_fitness = population_.front().fitness;
@@ -84,31 +105,33 @@ void MemeticIk::initPopulation(Robot const& robot,
     }
 
     computeExtinctions();
+    previous_fitness_.reset();
 }
 
 void MemeticIk::reproduce(Robot const& robot, CostFn const& cost_fn) {
-    std::vector<Individual*> pool;
-    pool.reserve(params_.elite_size);
+    // Reset mating pool
+    mating_pool_.resize(params_.elite_size);
     for (size_t i = 0; i < params_.elite_size; ++i) {
-        pool.emplace_back(&population_[i]);
+        mating_pool_[i] = &population_[i];
     }
 
     for (size_t i = params_.elite_size; i < params_.population_size; ++i) {
-        // Select parents
-        // TODO: Make this code better
-        if (pool.size() > 1) {
-            size_t const idxA = rsl::uniform_int<size_t>(0, pool.size());
+        // Select parents from the mating pool
+        // Note that we permit there being only one parent, which basically counts as just
+        // mutations.
+        if (!mating_pool_.empty()) {
+            size_t const idxA = rsl::uniform_int<size_t>(0, mating_pool_.size());
             size_t idxB = idxA;
-            while (idxB == idxA && pool.size() > 1) {
-                idxB = rsl::uniform_int<size_t>(0, pool.size());
+            while (idxB == idxA && mating_pool_.size() > 1) {
+                idxB = rsl::uniform_int<size_t>(0, mating_pool_.size());
             }
             auto& parentA = population_[idxA];
             auto& parentB = population_[idxB];
 
             // Get mutation probability
             double const extinction = 0.5 * (parentA.extinction + parentB.extinction);
-            double const inverse = 1.0 / static_cast<double>(robot.variables.size());
-            double const mutation_prob = extinction * (1.0 - inverse) + inverse;
+            double const mutation_prob =
+                extinction * (1.0 - inverse_gene_size_) + inverse_gene_size_;
 
             auto const mix_ratio = rsl::uniform_real(0.0, 1.0);
             for (size_t j_idx = 0; j_idx < robot.variables.size(); ++j_idx) {
@@ -131,21 +154,22 @@ void MemeticIk::reproduce(Robot const& robot, CostFn const& cost_fn) {
                 // Clamp to valid joint values
                 gene = std::clamp(gene, joint.clip_min, joint.clip_max);
 
-                // Approximate initial gradient
+                // Approximate gradient
                 population_[i].gradient[j_idx] = gene - original_gene;
             }
 
-            // Evaluate fitness.
+            // Evaluate fitness and remove parents from the mating pool if a child with better
+            // fitness exists.
             population_[i].fitness = cost_fn(population_[i].genes);
-
-            // Remove elements from the mating pool whose children have better fitness.
             if (population_[i].fitness < parentA.fitness)
-                pool.erase(remove(pool.begin(), pool.end(), &parentA), pool.end());
+                mating_pool_.erase(remove(mating_pool_.begin(), mating_pool_.end(), &parentA),
+                                   mating_pool_.end());
             if (population_[i].fitness < parentB.fitness)
-                pool.erase(remove(pool.begin(), pool.end(), &parentB), pool.end());
+                mating_pool_.erase(remove(mating_pool_.begin(), mating_pool_.end(), &parentB),
+                                   mating_pool_.end());
 
         } else {
-            // Roll a new population member randomly.
+            // If the mating pool is empty, roll a new population member randomly.
             for (size_t j_idx = 0; j_idx < robot.variables.size(); ++j_idx) {
                 auto const& var = robot.variables[j_idx];
                 population_[i].genes[j_idx] = rsl::uniform_real(0.0, 1.0) * var.span + var.min;
@@ -161,7 +185,7 @@ void MemeticIk::reproduce(Robot const& robot, CostFn const& cost_fn) {
 void MemeticIk::printPopulation() const {
     fmt::print("Fitnesses:\n");
     for (size_t i = 0; i < populationCount(); ++i) {
-        fmt::print("{}: {:.4f}\n", i, population_[i].fitness);
+        fmt::print("{}: {}\n", i, population_[i].fitness);
     }
     fmt::print("\n");
 }
@@ -170,6 +194,7 @@ void MemeticIk::sortPopulation() {
     std::sort(population_.begin(), population_.end(), [](Individual const& a, Individual const& b) {
         return a.fitness < b.fitness;
     });
+    computeExtinctions();
     best_curr_ = population_[0];
     if (best_curr_.fitness < best_.fitness) {
         best_ = best_curr_;
@@ -195,7 +220,6 @@ auto ik_memetic(std::vector<double> const& initial_guess,
 
     // Main loop
     int iter = 0;
-    std::optional<double> previous_fitness = std::nullopt;
     auto const timeout_point =
         std::chrono::system_clock::now() + std::chrono::duration<double>(timeout);
     while (std::chrono::system_clock::now() < timeout_point) {
@@ -207,37 +231,23 @@ auto ik_memetic(std::vector<double> const& initial_guess,
         // Perform mutation and recombination
         ik.reproduce(robot, cost_fn);
 
-        // Sort fitnesses
+        // Sort fitnesses and update extinctions
         ik.sortPopulation();
-        ik.computeExtinctions();
         if (print_debug) {
             fmt::print("Iteration {}\n", iter);
             ik.printPopulation();
         }
 
-        // Check for termination
+        // Check for termination and wipeout conditions
         if (solution_fn(ik.best().genes)) {
             if (print_debug) fmt::print("Found solution!\n");
             return ik.best().genes;
         }
-
-        // Handle wipeouts if no progress is being made.
-        if (previous_fitness.has_value()) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-            bool const improved =
-                (ik.bestCurrent().fitness < *previous_fitness - params.wipeout_fitness_tol);
-#pragma GCC diagnostic pop
-            if (!improved) {
-                if (print_debug) fmt::print("Population wipeout\n");
-                ik.initPopulation(robot, cost_fn, initial_guess);
-                previous_fitness.reset();
-            } else {
-                previous_fitness = ik.bestCurrent().fitness;
-            }
-        } else {
-            previous_fitness = ik.bestCurrent().fitness;
+        if (ik.checkWipeout()) {
+            if (print_debug) fmt::print("Population wipeout\n");
+            ik.initPopulation(robot, cost_fn, initial_guess);
         }
+
         iter++;
     }
 

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -64,7 +64,8 @@ void MemeticIk::sortPopulation() {
 void MemeticIk::selectPopulation(CostFn const& cost_fn) {
     for (size_t i = 0; i < populationSize(); ++i) {
         if (i >= elite_count_) {
-            population_[i] = population_[i - elite_count_]; // Bad selection criteria, should sample
+            population_[i] =
+                population_[i - elite_count_];  // Bad selection criteria, should sample
             for (auto& val : population_[i].genes) {
                 val += dist_(gen_);  // Bad mutation criteria
             }
@@ -118,7 +119,7 @@ auto ik_memetic(std::vector<double> const& initial_guess,
 
     if (approx_solution) {
         std::cout << "Returning best solution." << std::endl;
-    //     return population_[0];
+        //     return population_[0];
     }
 
     return std::nullopt;

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -36,7 +36,9 @@ void MemeticIk::gradientDescent(size_t const i, Robot const& robot, CostFn const
 
     int iter = 0;
     while (std::chrono::system_clock::now() < timeout_point_local && iter < max_iters_local) {
-        step(local_ik, robot, cost_fn);
+        if (!step(local_ik, robot, cost_fn)) {
+            break;
+        }
         iter++;
     }
 

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -1,4 +1,5 @@
 pick_ik:
+  # Overall solver settings
   mode: {
     type: string,
     default_value: "global",
@@ -7,6 +8,15 @@ pick_ik:
       one_of<>: [["global", "local"]]
     }
   }
+  gd_step_size: {
+    type: double,
+    default_value: 0.0001,
+    description: "Gradient descent step size for joint perturbation",
+    validation: {
+      lower_bounds<>: [1.0e-12],
+    }
+  }
+  # Cost functions and thresholds
   twist_threshold: {
     type: double,
     default_value: 0.001,
@@ -45,4 +55,45 @@ pick_ik:
     validation: {
       lower_bounds<>: [0.0],
     },
+  }
+  # Memetic IK specific parameters
+  memetic_population_size: {
+    type: int,
+    default_value: 16,
+    description: "Population size for memetic IK",
+    validation: {
+      lower_bounds<>: [1],
+    }
+  }
+  memetic_elite_size: {
+    type: int,
+    default_value: 4,
+    description: "Number of elite members of memetic IK population",
+    validation: {
+      lower_bounds<>: [1],
+    }
+  }
+  memetic_wipeout_fitness_tol: {
+    type: double,
+    default_value: 0.00001,
+    description: "Minimum fitness must improve by this value or population will be wiped out",
+    validation: {
+      lower_bounds<>: [0.0],
+    }
+  }
+  memetic_gd_max_iters: {
+    type: int,
+    default_value: 25,
+    description: "Maximum iterations of gradient descent during memetic exploitation",
+    validation: {
+      lower_bounds<>: [0],
+    }
+  }
+  memetic_gd_max_time: {
+    type: double,
+    default_value: 0.005,
+    description: "Maximum time spent on gradient descent during memetic exploitation",
+    validation: {
+      lower_bounds<>: [0.0],
+    }
   }

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -1,4 +1,12 @@
 pick_ik:
+  mode: {
+    type: string,
+    default_value: "global",
+    description: "IK solver mode. Set to global to allow the initial guess to be a long distance from the goal, or local if the initial guess is near the goal.",
+    validation: {
+      one_of<>: [["global", "local"]]
+    }
+  }
   twist_threshold: {
     type: double,
     default_value: 0.00001,

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -9,12 +9,12 @@ pick_ik:
   }
   twist_threshold: {
     type: double,
-    default_value: 0.00001,
+    default_value: 0.001,
     description: "Twist threshold for solving IK, epsilon",
   }
   cost_threshold: {
     type: double,
-    default_value: 0.00001,
+    default_value: 0.001,
     description: "Scalar value for comparing to result of cost functions. Ik is considered solved when all pos/rot/twist thresholds are satisfied and all cost functions return a value lower than this value."
   }
   rotation_scale: {

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -156,20 +156,30 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         // Search for a solution using either the local or global solver.
         std::optional<std::vector<double>> maybe_solution;
         if (params.mode == "global") {
+            MemeticIkParams ik_params;
+            ik_params.population_size = static_cast<size_t>(params.memetic_population_size);
+            ik_params.elite_size = static_cast<size_t>(params.memetic_elite_size);
+            ik_params.wipeout_fitness_tol = params.memetic_wipeout_fitness_tol;
+            ik_params.local_step_size = params.gd_step_size;
+            ik_params.local_max_iters = static_cast<int>(params.memetic_gd_max_iters);
+            ik_params.local_max_time = params.memetic_gd_max_time;
+
             maybe_solution = ik_memetic(ik_seed_state,
                                         robot_,
                                         cost_fn,
                                         solution_fn,
+                                        ik_params,
                                         timeout,
                                         options.return_approximate_solution,
                                         false /* No debug print */);
         } else if (params.mode == "local") {
-            maybe_solution = ik_search(ik_seed_state,
-                                       robot_,
-                                       cost_fn,
-                                       solution_fn,
-                                       timeout,
-                                       options.return_approximate_solution);
+            maybe_solution = ik_gradient(ik_seed_state,
+                                         robot_,
+                                         cost_fn,
+                                         solution_fn,
+                                         timeout,
+                                         options.return_approximate_solution,
+                                         params.gd_step_size);
         } else {
             RCLCPP_ERROR(LOGGER, "Invalid solver mode: %s", params.mode.c_str());
             return false;

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -161,7 +161,8 @@ class PickIKPlugin : public kinematics::KinematicsBase {
                                         cost_fn,
                                         solution_fn,
                                         timeout,
-                                        options.return_approximate_solution);
+                                        options.return_approximate_solution,
+                                        false /* No debug print */);
         } else if (params.mode == "local") {
             maybe_solution = ik_search(ik_seed_state,
                                        robot_,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,9 +3,10 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Catch2 3.1.0 REQUIRED)
 
 add_executable(test-pick_ik
-    goal_tests.cpp
-    ik_tests.cpp
-    robot_tests.cpp
+    # goal_tests.cpp
+    # ik_tests.cpp
+    ik_memetic_tests.cpp
+    # robot_tests.cpp
 )
 target_link_libraries(test-pick_ik
         PRIVATE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,10 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 find_package(Catch2 3.1.0 REQUIRED)
 
 add_executable(test-pick_ik
-    # goal_tests.cpp
-    # ik_tests.cpp
+    goal_tests.cpp
+    ik_tests.cpp
     ik_memetic_tests.cpp
-    # robot_tests.cpp
+    robot_tests.cpp
 )
 target_link_libraries(test-pick_ik
         PRIVATE

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -68,13 +68,57 @@ TEST_CASE("Panda model IK") {
     std::vector<double> const home_joint_angles =
         {0.0, -M_PI_4, 0.0, -3.0 * M_PI_4, 0.0, M_PI_2, M_PI_4};
 
+    // SECTION("Panda model IK at home positions.") {
+    //     auto const goal_frame = fk_fn(home_joint_angles)[0];
+    //     auto initial_guess = home_joint_angles;
+    //     MemeticIkTestParams params;
+    //     params.cost_threshold = 0.0001;
+    //     params.twist_threshold = 0.0001;
+    //     params.timeout = 10.0;
+
+    //     auto const maybe_solution = solve_memetic_ik_test(robot_model,
+    //                                                       "panda_arm",
+    //                                                       "panda_hand",
+    //                                                       goal_frame,
+    //                                                       initial_guess,
+    //                                                       params);
+
+    //     REQUIRE(maybe_solution.has_value());
+    //     auto const final_frame = fk_fn(maybe_solution.value())[0];
+    //     CHECK(goal_frame.isApprox(final_frame, params.twist_threshold));
+    // }
+
+    // SECTION("Panda model IK near home positions.") {
+    //     auto const goal_frame = fk_fn(home_joint_angles)[0];
+    //     auto initial_guess = home_joint_angles;
+    //     std::vector<double> const initial_guess_offsets = {0.1, -0.1, 0.0, 0.1, -0.1, 0.0, 0.1};
+    //     for (size_t i=0; i < initial_guess.size(); ++i) {
+    //         initial_guess[i] += initial_guess_offsets[i];
+    //     }
+    //     MemeticIkTestParams params;
+    //     params.cost_threshold = 0.0001;
+    //     params.twist_threshold = 0.0001;
+    //     params.timeout = 10.0;
+
+    //     auto const maybe_solution = solve_memetic_ik_test(robot_model,
+    //                                                       "panda_arm",
+    //                                                       "panda_hand",
+    //                                                       goal_frame,
+    //                                                       initial_guess,
+    //                                                       params);
+
+    //     REQUIRE(maybe_solution.has_value());
+    //     auto const final_frame = fk_fn(maybe_solution.value())[0];
+    //     CHECK(goal_frame.isApprox(final_frame, params.twist_threshold));
+    // }
+
     SECTION("Panda model IK at zero positions.") {
         auto const goal_frame = fk_fn(home_joint_angles)[0];
         auto const initial_guess = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         MemeticIkTestParams params;
         params.cost_threshold = 0.0001;
         params.twist_threshold = 0.0001;
-        params.timeout = 30.0;
+        params.timeout = 15.0;
 
         auto const maybe_solution = solve_memetic_ik_test(robot_model,
                                                           "panda_arm",

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -114,7 +114,7 @@ TEST_CASE("Panda model Memetic IK") {
         auto const goal_frame = fk_fn(home_joint_angles)[0];
         auto initial_guess = home_joint_angles;
         std::vector<double> const initial_guess_offsets = {0.1, -0.1, 0.0, 0.1, -0.1, 0.0, 0.1};
-        for (size_t i=0; i < initial_guess.size(); ++i) {
+        for (size_t i = 0; i < initial_guess.size(); ++i) {
             initial_guess[i] += initial_guess_offsets[i];
         }
         MemeticIkTestParams params;

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -10,7 +10,6 @@
 
 #include <Eigen/Geometry>
 #include <cmath>
-#include <iostream>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/utils/robot_model_test_utils.h>
 
@@ -23,6 +22,7 @@ struct MemeticIkTestParams {
     // Solve options
     double timeout = 1.0;
     bool approximate_solution = false;
+    bool print_debug = false;
 
     // Additional costs
     double center_joints_weight = 0.0;
@@ -78,10 +78,11 @@ auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
                                cost_fn,
                                solution_fn,
                                params.timeout,
-                               params.approximate_solution);
+                               params.approximate_solution,
+                               params.print_debug);
 }
 
-TEST_CASE("Panda model IK") {
+TEST_CASE("Panda model Memetic IK") {
     using moveit::core::loadTestingRobotModel;
     auto const robot_model = loadTestingRobotModel("panda");
 
@@ -156,6 +157,7 @@ TEST_CASE("Panda model IK") {
         params.avoid_joint_limits_weight = 0.01;
         params.cost_threshold = 0.01;  // Need to raise this for joint centering
         params.twist_threshold = 0.01;
+        params.print_debug = true;
 
         auto const maybe_solution = solve_memetic_ik_test(robot_model,
                                                           "panda_arm",

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -20,7 +20,7 @@ struct MemeticIkTestParams {
     double cost_threshold = 0.00001;
     double rotation_scale = 0.5;
     double timeout = 1.0;
-    bool return_approximate_solution = false;
+    bool approximate_solution = false;
 };
 
 auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
@@ -53,7 +53,12 @@ auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
     // Solve IK
     auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
     auto const cost_fn = pick_ik::make_cost_fn(pose_cost_functions, goals, fk_fn);
-    return pick_ik::ik_memetic(initial_guess, robot, cost_fn, solution_fn, params.timeout, true);
+    return pick_ik::ik_memetic(initial_guess,
+                               robot,
+                               cost_fn,
+                               solution_fn,
+                               params.timeout,
+                               params.approximate_solution);
 }
 
 TEST_CASE("Panda model IK") {

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -15,14 +15,15 @@
 
 // Helper param struct and function to test IK solution.
 struct MemeticIkTestParams {
-    double twist_threshold = 0.00001;
-    double cost_threshold = 0.00001;
+    double twist_threshold = 0.001;
+    double cost_threshold = 0.001;
     double rotation_scale = 0.5;
 
     // Solve options
     double timeout = 1.0;
     bool approximate_solution = false;
     bool print_debug = false;
+    pick_ik::MemeticIkParams memetic_params;
 
     // Additional costs
     double center_joints_weight = 0.0;
@@ -77,6 +78,7 @@ auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
                                robot,
                                cost_fn,
                                solution_fn,
+                               params.memetic_params,
                                params.timeout,
                                params.approximate_solution,
                                params.print_debug);
@@ -157,7 +159,7 @@ TEST_CASE("Panda model Memetic IK") {
         params.avoid_joint_limits_weight = 0.01;
         params.cost_threshold = 0.01;  // Need to raise this for joint centering
         params.twist_threshold = 0.01;
-        params.print_debug = true;
+        params.print_debug = false;
 
         auto const maybe_solution = solve_memetic_ik_test(robot_model,
                                                           "panda_arm",

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -23,7 +23,6 @@ struct MemeticIkTestParams {
     bool return_approximate_solution = false;
 };
 
-
 auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
                            std::string const group_name,
                            std::string const goal_frame_name,

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -16,9 +16,9 @@
 
 // Helper param struct and function to test IK solution.
 struct MemeticIkTestParams {
-    double twist_threshold = 0.0001;
-    double cost_threshold = 0.0001;
-    double rotation_scale = 1.0;
+    double twist_threshold = 0.00001;
+    double cost_threshold = 0.00001;
+    double rotation_scale = 0.5;
     double timeout = 1.0;
     bool return_approximate_solution = false;
 };
@@ -71,9 +71,6 @@ TEST_CASE("Panda model IK") {
     //     auto const goal_frame = fk_fn(home_joint_angles)[0];
     //     auto initial_guess = home_joint_angles;
     //     MemeticIkTestParams params;
-    //     params.cost_threshold = 0.0001;
-    //     params.twist_threshold = 0.0001;
-    //     params.timeout = 10.0;
 
     //     auto const maybe_solution = solve_memetic_ik_test(robot_model,
     //                                                       "panda_arm",
@@ -95,9 +92,6 @@ TEST_CASE("Panda model IK") {
     //         initial_guess[i] += initial_guess_offsets[i];
     //     }
     //     MemeticIkTestParams params;
-    //     params.cost_threshold = 0.0001;
-    //     params.twist_threshold = 0.0001;
-    //     params.timeout = 10.0;
 
     //     auto const maybe_solution = solve_memetic_ik_test(robot_model,
     //                                                       "panda_arm",
@@ -115,9 +109,6 @@ TEST_CASE("Panda model IK") {
         auto const goal_frame = fk_fn(home_joint_angles)[0];
         auto const initial_guess = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
         MemeticIkTestParams params;
-        params.cost_threshold = 0.0001;
-        params.twist_threshold = 0.0001;
-        params.timeout = 15.0;
 
         auto const maybe_solution = solve_memetic_ik_test(robot_model,
                                                           "panda_arm",

--- a/tests/ik_memetic_tests.cpp
+++ b/tests/ik_memetic_tests.cpp
@@ -1,0 +1,90 @@
+#include <pick_ik/fk_moveit.hpp>
+#include <pick_ik/goal.hpp>
+#include <pick_ik/ik_gradient.hpp>
+#include <pick_ik/ik_memetic.hpp>
+#include <pick_ik/robot.hpp>
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <Eigen/Geometry>
+#include <cmath>
+#include <iostream>
+#include <moveit/kinematics_base/kinematics_base.h>
+#include <moveit/utils/robot_model_test_utils.h>
+
+// Helper param struct and function to test IK solution.
+struct MemeticIkTestParams {
+    double twist_threshold = 0.0001;
+    double cost_threshold = 0.0001;
+    double rotation_scale = 1.0;
+    double timeout = 1.0;
+    bool return_approximate_solution = false;
+};
+
+
+auto solve_memetic_ik_test(moveit::core::RobotModelPtr robot_model,
+                           std::string const group_name,
+                           std::string const goal_frame_name,
+                           Eigen::Isometry3d const& goal_frame,
+                           std::vector<double> const& initial_guess,
+                           MemeticIkTestParams const& params = MemeticIkTestParams())
+    -> std::optional<std::vector<double>> {
+    // Make forward kinematics function
+    auto const jmg = robot_model->getJointModelGroup(group_name);
+    auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {goal_frame_name}).value();
+    auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
+
+    // Make solution function
+    auto const test_rotation = (params.rotation_scale > 0.0);
+    auto const frame_tests =
+        pick_ik::make_frame_tests({goal_frame}, params.twist_threshold, test_rotation);
+    auto const cost_function =
+        kinematics::KinematicsBase::IKCostFn();  // What should be instantiated here?
+    std::vector<pick_ik::Goal> goals = {};       // TODO: Only works if empty.
+    auto const solution_fn =
+        pick_ik::make_is_solution_test_fn(frame_tests, goals, params.cost_threshold, fk_fn);
+
+    // Make pose cost function
+    auto const pose_cost_functions =
+        pick_ik::make_pose_cost_functions({goal_frame}, params.rotation_scale);
+    CHECK(pose_cost_functions.size() == 1);
+
+    // Solve IK
+    auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
+    auto const cost_fn = pick_ik::make_cost_fn(pose_cost_functions, goals, fk_fn);
+    return pick_ik::ik_memetic(initial_guess, robot, cost_fn, solution_fn, params.timeout, true);
+}
+
+TEST_CASE("Panda model IK") {
+    using moveit::core::loadTestingRobotModel;
+    auto const robot_model = loadTestingRobotModel("panda");
+
+    auto const jmg = robot_model->getJointModelGroup("panda_arm");
+    auto const tip_link_indices = pick_ik::get_link_indices(robot_model, {"panda_hand"}).value();
+    auto const fk_fn = pick_ik::make_fk_fn(robot_model, jmg, tip_link_indices);
+
+    std::vector<double> const home_joint_angles =
+        {0.0, -M_PI_4, 0.0, -3.0 * M_PI_4, 0.0, M_PI_2, M_PI_4};
+
+    SECTION("Panda model IK at zero positions.") {
+        auto const goal_frame = fk_fn(home_joint_angles)[0];
+        auto const initial_guess = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        MemeticIkTestParams params;
+        params.cost_threshold = 0.0001;
+        params.twist_threshold = 0.0001;
+        params.timeout = 30.0;
+
+        auto const maybe_solution = solve_memetic_ik_test(robot_model,
+                                                          "panda_arm",
+                                                          "panda_hand",
+                                                          goal_frame,
+                                                          initial_guess,
+                                                          params);
+
+        REQUIRE(maybe_solution.has_value());
+        auto const final_frame = fk_fn(maybe_solution.value())[0];
+        CHECK(goal_frame.isApprox(final_frame, params.twist_threshold));
+    }
+}

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -9,7 +9,6 @@
 
 #include <Eigen/Geometry>
 #include <cmath>
-#include <iostream>
 #include <moveit/kinematics_base/kinematics_base.h>
 #include <moveit/utils/robot_model_test_utils.h>
 

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -80,6 +80,7 @@ struct IkTestParams {
     double rotation_scale = 1.0;
     double timeout = 1.0;
     bool return_approximate_solution = false;
+    double step_size = 0.0001;
 };
 
 auto solve_ik_test(moveit::core::RobotModelPtr robot_model,
@@ -112,12 +113,13 @@ auto solve_ik_test(moveit::core::RobotModelPtr robot_model,
     // Solve IK
     auto const robot = pick_ik::Robot::from(robot_model, jmg, tip_link_indices);
     auto const cost_fn = pick_ik::make_cost_fn(pose_cost_functions, goals, fk_fn);
-    return pick_ik::ik_search(initial_guess,
-                              robot,
-                              cost_fn,
-                              solution_fn,
-                              params.timeout,
-                              params.return_approximate_solution);
+    return pick_ik::ik_gradient(initial_guess,
+                                robot,
+                                cost_fn,
+                                solution_fn,
+                                params.timeout,
+                                params.return_approximate_solution,
+                                params.step_size);
 }
 
 TEST_CASE("RR model IK") {
@@ -248,7 +250,7 @@ TEST_CASE("Panda model IK") {
                                                   params);
 
         REQUIRE(maybe_solution.has_value());
-        for (size_t i = 0; i < 7; ++i) {
+        for (size_t i = 0; i < initial_guess.size(); ++i) {
             CHECK(maybe_solution.value()[i] == Catch::Approx(home_joint_angles[i]).margin(0.01));
         }
     }
@@ -270,8 +272,8 @@ TEST_CASE("Panda model IK") {
                                                   params);
 
         REQUIRE(maybe_solution.has_value());
-        for (size_t i = 0; i < 7; ++i) {
-            // NOTE the extra tolerance...
+        for (size_t i = 0; i < initial_guess.size(); ++i) {
+            // Note the extra tolerance...
             CHECK(maybe_solution.value()[i] == Catch::Approx(actual_joint_angles[i]).margin(0.025));
         }
     }


### PR DESCRIPTION
A bunch of the memetic (global) solver from Bio IK has been ported over.

Through a lot of testing and iteration, I consolidated what was on the [paper](https://www.starke-consult.de/portfolio/assets/content/work/6/paper.pdf), plus what was in the Bio IK ROS package's solvers, `ik_evolution_1` and `ik_evolution_2`.

I think a lot remains in cleaning up code / interfaces / parameters, plus maybe some more focused unit tests rather than just "test the entire memetic algorithm". So please focus on this for review, particularly where you can identify performance improvements.

Some things that still remain to do and are out of scope for this PR:
* Multi-threading with multiple species
* Switching time from chrono to rclcpp (are we doing this?)
* Cleaning up RNG (probably best to just wait for RSL release for this)
* Cartesian interpolation using this IK solver (both local and global)