### PR TITLE
Fix joint limits logic

### DIFF
--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -96,7 +96,7 @@ void MemeticIk::initPopulation(Robot const& robot,
         if (i > 0) {
             for (size_t j_idx = 0; j_idx < robot.variables.size(); ++j_idx) {
                 auto const& var = robot.variables[j_idx];
-                genotype[j_idx] = rsl::uniform_real(0.0, 1.0) * var.span + var.min;
+                genotype[j_idx] = rsl::uniform_real(var.clip_min, var.clip_max);
             }
         }
         population_[i] = Individual{genotype, cost_fn(genotype), 1.0, zero_grad};
@@ -177,7 +177,7 @@ void MemeticIk::reproduce(Robot const& robot, CostFn const& cost_fn) {
             // If the mating pool is empty, roll a new population member randomly.
             for (size_t j_idx = 0; j_idx < robot.variables.size(); ++j_idx) {
                 auto const& var = robot.variables[j_idx];
-                population_[i].genes[j_idx] = rsl::uniform_real(0.0, 1.0) * var.span + var.min;
+                population_[i].genes[j_idx] = rsl::uniform_real(var.clip_min, var.clip_max);
             }
             population_[i].fitness = cost_fn(population_[i].genes);
             for (auto& g : population_[i].gradient) {

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -188,10 +188,14 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         }
 
         if (maybe_solution.has_value()) {
-            // set the output parameter solution and wrap angles
+            // Set the output parameter solution.
+            // Assumes that the angles were already wrapped by the solver.
             error_code.val = error_code.SUCCESS;
             solution = maybe_solution.value();
-            jmg_->enforcePositionBounds(solution.data());
+            if (jmg_->enforcePositionBounds(solution.data())) {
+                error_code.val = error_code.NO_IK_SOLUTION;
+                solution = ik_seed_state;
+            }
         } else {
             error_code.val = error_code.NO_IK_SOLUTION;
             solution = ik_seed_state;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -35,14 +35,6 @@ auto Robot::from(std::shared_ptr<moveit::core::RobotModel const> const& model,
 
         bool bounded = bounds.position_bounded_;
 
-        auto const* joint_model =
-            model->getJointOfVariable(static_cast<int>(robot.variables.size()));
-        if (dynamic_cast<moveit::core::RevoluteJointModel const*>(joint_model)) {
-            if (bounds.max_position_ - bounds.min_position_ >= 2 * M_PI * 0.9999) {
-                bounded = false;
-            }
-        }
-
         var.min = bounds.min_position_;
         var.max = bounds.max_position_;
 


### PR DESCRIPTION
Found an issue in `robot.cpp` that would invalidate joint bounds if their range wasn't good.

For now I've removed this, and also removed the joints bounding at the end of the plugin. However, if we find a solution and after limiting it we find it changed, we throw it away.

Interested in other thoughts.