### PR TITLE
Split twist threshold into position and orientation

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -13,7 +13,8 @@ panda_arm:
   kinematics_solver_attempts: 3
   mode: global
   rotation_scale: 0.5
-  twist_threshold: 0.001
+  position_threshold: 0.001
+  orientation_threshold: 0.01
   cost_threshold: 0.001
   minimal_displacement_weight: 0.0
   gd_step_size: 0.0001
@@ -31,10 +32,10 @@ Some key parameters you may want to start with are:
 
 * `mode`: If you choose `local`, this solver will only do local gradient descent; If you choose `global`, it will also enable the evolutionary algorithm. Using the global solver will be less performant, but if you're having trouble getting out of local minima, this could help you. We recommend using `local` for things like relative motion / Cartesian interpolation / endpoint jogging, and `global` if you need to solve for goals with a far-away initial conditions.
 * `memetic_<property>`: All the properties that only kick in if you use the `global` solver. The key one is `memetic_num_threads`, as we have enabled the evolutionary algorithm to solve on multiple threads.
-* `cost_threshold`: This solver works by setting up cost functions based on how far away your pose is, how much your joints move relative to the initial guess, and custom cost functions you can add. Optimization succeeds only if the cost is less than `cost_threshold`. Note that if you're adding custom cost functions, you may want to set this threshold fairly high and rely on `twist_threshold` to be your deciding factor whereas this is more of a guideline.
-* `twist_threshold`: Optimization succeeds only if the pose difference is less than `twist_threshold`. So, e.g., assuming your orientation was perfectly met, a `twist_threshold` of 0.001 would mean a 1 mm accuracy.
-* `approximate_solution_twist_threshold`: When using approximate IK solutions for applications such as endpoint servoing, `pick_ik` may sometimes return solutions that are significantly far from the goal frame. To prevent issues with such jumps in solutions, this parameter defines a maximum displacement. We recommend setting this to values around 0.01 - 0.05 (1-5 cm) for most applications.
-* `rotation_scale`: If you want position-only IK, set this to 0.0. If you want to treat position and orientation equally, set this to 1.0. You can also use any value in between; it's part of the cost function. Note that the exit condition on `twist_threshold` will ignore orientation if you use `rotation_scale = 0.0`.
+* `cost_threshold`: This solver works by setting up cost functions based on how far away your pose is, how much your joints move relative to the initial guess, and custom cost functions you can add. Optimization succeeds only if the cost is less than `cost_threshold`. Note that if you're adding custom cost functions, you may want to set this threshold fairly high and rely on `position_threshold` and `orientation_threshold` to be your deciding factors, whereas this is more of a guideline.
+* `position_threshold`/`orientation_threshold`: Optimization succeeds only if the pose difference. is less than these thresholds in meters and radians respectively. So `position_threshold` of 0.001 would mean a 1 mm accuracy and `orientation_threshold` of 0.01 would mean a 0.01 radian accuracy.
+* `approximate_solution_position_threshold`/`approximate_position_orientation_threshold`: When using approximate IK solutions for applications such as endpoint servoing, `pick_ik` may sometimes return solutions that are significantly far from the goal frame. To prevent issues with such jumps in solutions, these parameters define maximum translational and rotation displacement. We recommend setting this to values around a few centimeters and a few degrees for most applications.
+* `rotation_scale`: If you want position-only IK, set this to 0.0. If you want to treat position and orientation equally, set this to 1.0. You can also use any value in between; it's part of the cost function. Note that any checks using `orientation_threshold` will be ignored if you use `rotation_scale = 0.0`.
 * `minimal_displacement_weight`: This is one of the standard cost functions that checks for the joint angle difference between the initial guess and the solution. If you're solving for far-away goals, leave it to zero or it will hike up your cost function for no reason. Have this to a small non-zero value (e.g., 0.001) if you're doing things like Cartesian interpolation along a path, or endpoint jogging for servoing.
 
 You can test out this solver live in RViz, as this plugin uses the [`generate_parameter_library`](https://github.com/PickNikRobotics/generate_parameter_library) package to respond to parameter changes at every solve. This means that you can change values on the fly using the ROS 2 command-line interface, e.g.,

--- a/include/pick_ik/goal.hpp
+++ b/include/pick_ik/goal.hpp
@@ -16,8 +16,9 @@ namespace pick_ik {
 // Frame equality tests
 using FrameTestFn = std::function<bool(Eigen::Isometry3d const& tip_frame)>;
 auto make_frame_tests(std::vector<Eigen::Isometry3d> goal_frames,
-                      double twist_threshold,
-                      bool test_rotation = true) -> std::vector<FrameTestFn>;
+                      double position_threshold,
+                      std::optional<double> orientation_threshold = std::nullopt)
+    -> std::vector<FrameTestFn>;
 
 // Pose cost functions
 using PoseCostFn = std::function<double(std::vector<Eigen::Isometry3d> const& tip_frames)>;

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -33,18 +33,34 @@ pick_ik:
     }
   }
   # Cost functions and thresholds
-  twist_threshold: {
+  position_threshold: {
     type: double,
     default_value: 0.001,
-    description: "Twist threshold for solving IK, epsilon",
+    description: "Position threshold for solving IK, in meters",
     validation: {
       lower_bounds<>: [0.0],
     },
   }
-  approximate_solution_twist_threshold: {
+  orientation_threshold: {
+    type: double,
+    default_value: 0.001,
+    description: "Orientation threshold for solving IK, in radians",
+    validation: {
+      lower_bounds<>: [0.0],
+    },
+  }
+  approximate_solution_position_threshold: {
     type: double,
     default_value: 0.05,
-    description: "Twist threshold for approximate IK solutions. If displacement is larger than this, the approximate solution will fall back to the initial guess",
+    description: "Position threshold for approximate IK solutions, in meters. If displacement is larger than this, the approximate solution will fall back to the initial guess",
+    validation: {
+      lower_bounds<>: [0.0],
+    },
+  }
+  approximate_solution_orientation_threshold: {
+    type: double,
+    default_value: 0.05,
+    description: "Orientation threshold for approximate IK solutions, in radians. If displacement is larger than this, the approximate solution will fall back to the initial guess",
     validation: {
       lower_bounds<>: [0.0],
     },

--- a/tests/ik_tests.cpp
+++ b/tests/ik_tests.cpp
@@ -75,7 +75,8 @@ TEST_CASE("RR model FK") {
 
 // Helper param struct and function to test IK solution.
 struct IkTestParams {
-    double twist_threshold = 0.0001;
+    double position_threshold = 0.0001;
+    double orientation_threshold = 0.001;
     double cost_threshold = 0.0001;
     double rotation_scale = 1.0;
     bool return_approximate_solution = false;
@@ -96,8 +97,12 @@ auto solve_ik_test(moveit::core::RobotModelPtr robot_model,
 
     // Make solution function
     auto const test_rotation = (params.rotation_scale > 0.0);
+    std::optional<double> orientation_threshold = std::nullopt;
+    if (test_rotation) {
+        orientation_threshold = params.orientation_threshold;
+    }
     auto const frame_tests =
-        pick_ik::make_frame_tests({goal_frame}, params.twist_threshold, test_rotation);
+        pick_ik::make_frame_tests({goal_frame}, params.position_threshold, orientation_threshold);
     auto const cost_function =
         kinematics::KinematicsBase::IKCostFn();  // What should be instantiated here?
     std::vector<pick_ik::Goal> goals = {};       // TODO: Only works if empty.


### PR DESCRIPTION
Based on @henningkayser 's comment on https://github.com/PickNikRobotics/pick_ik/issues/20 and @AndyZe 's comment on https://github.com/PickNikRobotics/pick_ik/pull/25, it was clear we needed to rename `twist_threshold` to something more intuitive.

This PR splits that threshold into separate position and orientation weight parameters.

Closes #20