### PR TITLE
Fix orientation calculation in cost function and frame tests

### DIFF
--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -21,7 +21,7 @@ auto make_frame_test_fn(Eigen::Isometry3d goal_frame,
         auto const q_goal = Eigen::Quaterniond(goal_frame.rotation());
         auto const q_frame = Eigen::Quaterniond(tip_frame.rotation());
         auto const q_dot_product = std::clamp(q_goal.dot(q_frame), -1.0, 1.0);
-        auto const angular_distance = 2.0 * std::acos(q_dot_product);
+        auto const angular_distance = 2.0 * std::acos(std::abs(q_dot_product));
         return ((goal_frame.translation() - tip_frame.translation()).norm() <=
                 position_threshold) &&
                (!orientation_threshold.has_value() ||
@@ -50,7 +50,7 @@ auto make_pose_cost_fn(Eigen::Isometry3d goal, size_t goal_link_index, double ro
             auto const& frame = tip_frames[goal_link_index];
             auto const q_frame = Eigen::Quaterniond(frame.rotation());
             auto const q_dot_product = std::clamp(q_goal.dot(q_frame), -1.0, 1.0);
-            auto const angular_distance = 2.0 * std::acos(q_dot_product);
+            auto const angular_distance = 2.0 * std::acos(std::abs(q_dot_product));
             return (goal.translation() - frame.translation()).squaredNorm() +
                    std::pow(angular_distance * rotation_scale, 2);
         };

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -20,8 +20,7 @@ auto make_frame_test_fn(Eigen::Isometry3d goal_frame,
     return [=](Eigen::Isometry3d const& tip_frame) -> bool {
         auto const q_goal = Eigen::Quaterniond(goal_frame.rotation());
         auto const q_frame = Eigen::Quaterniond(tip_frame.rotation());
-        auto const q_dot_product = std::clamp(q_goal.dot(q_frame), -1.0, 1.0);
-        auto const angular_distance = 2.0 * std::acos(std::abs(q_dot_product));
+        auto const angular_distance = q_frame.angularDistance(q_goal);
         return ((goal_frame.translation() - tip_frame.translation()).norm() <=
                 position_threshold) &&
                (!orientation_threshold.has_value() ||
@@ -49,8 +48,7 @@ auto make_pose_cost_fn(Eigen::Isometry3d goal, size_t goal_link_index, double ro
         return [=](std::vector<Eigen::Isometry3d> const& tip_frames) -> double {
             auto const& frame = tip_frames[goal_link_index];
             auto const q_frame = Eigen::Quaterniond(frame.rotation());
-            auto const q_dot_product = std::clamp(q_goal.dot(q_frame), -1.0, 1.0);
-            auto const angular_distance = 2.0 * std::acos(std::abs(q_dot_product));
+            auto const angular_distance = q_frame.angularDistance(q_goal);
             return (goal.translation() - frame.translation()).squaredNorm() +
                    std::pow(angular_distance * rotation_scale, 2);
         };

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -204,10 +204,6 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             // Assumes that the angles were already wrapped by the solver.
             error_code.val = error_code.SUCCESS;
             solution = maybe_solution.value();
-            if (jmg_->enforcePositionBounds(solution.data())) {
-                error_code.val = error_code.NO_IK_SOLUTION;
-                solution = ik_seed_state;
-            }
         } else {
             error_code.val = error_code.NO_IK_SOLUTION;
             solution = ik_seed_state;

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -246,7 +246,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             solution_callback(ik_poses.front(), solution, error_code);
         }
 
-        return found_solution;
+        return error_code.val == error_code.SUCCESS;
     }
 
     virtual std::vector<std::string> const& getJointNames() const { return joint_names_; }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -43,7 +43,7 @@ auto Robot::from(std::shared_ptr<moveit::core::RobotModel const> const& model,
 
         var.span = var.max - var.min;
 
-        if (!(var.span >= 0 && var.span < FLT_MAX)) var.span = 1;
+        if (!(var.span >= 0 && var.span < std::numeric_limits<double>::max())) var.span = 1;
 
         auto const max_velocity = bounds.max_velocity_;
         var.max_velocity_rcp = max_velocity > 0.0 ? 1.0 / max_velocity : 0.0;


### PR DESCRIPTION
In some issues that were filed recently, we discovered that the rotation cost was the biggest computational bottleneck.

Then, after talking to @stephanie-eng we realized the best path is to look at what `bio_ik` did -- specifically, they use the [following KDL function](https://github.com/PickNikRobotics/bio_ik/blob/master/src/problem.cpp#L291) whose implementation is [here](http://docs.ros.org/en/lunar/api/tf2/html/Quaternion_8h_source.html#:~:text=218%C2%A0%20%20%20%20%20%20%20%20tf2Scalar,226%C2%A0%20%20%20%20%20%20%20%20%7D), which negates the quaternion dot product if it's less than zero because of "short vs. long path" of calculating an angle.

Anyway, this sped up my results significantly when testing locally!