### PR TITLE
Fix searchPositionIK usage of IKCostFn

### DIFF
--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -98,7 +98,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         std::vector<double> const&,
         std::vector<double>& solution,
         IKCallbackFn const& solution_callback,
-        IKCostFn cost_function,
+        const IKCostFn& cost_function,
         moveit_msgs::msg::MoveItErrorCodes& error_code,
         kinematics::KinematicsQueryOptions const& options = kinematics::KinematicsQueryOptions(),
         moveit::core::RobotState const* context_state = nullptr) const {

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -98,7 +98,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
         std::vector<double> const&,
         std::vector<double>& solution,
         IKCallbackFn const& solution_callback,
-        const IKCostFn& cost_function,
+        IKCostFn const& cost_function,
         moveit_msgs::msg::MoveItErrorCodes& error_code,
         kinematics::KinematicsQueryOptions const& options = kinematics::KinematicsQueryOptions(),
         moveit::core::RobotState const* context_state = nullptr) const {


### PR DESCRIPTION
When I provide a custom cost function to a setFromIK call it will result in the error
`"This kinematic solver does not support IK solution cost functions"`
I think this is due to the fact that the method [searchIKPosition()](https://github.com/ros-planning/moveit2/blob/f9d44b6eb8d22b00e9ff9b53585f762a6976c0aa/moveit_core/kinematics_base/include/moveit/kinematics_base/kinematics_base.h#LL351C3-L367C4) is not correctly replaced by the implementation in pick_ik due to a different method signature.
If the change below is applied, the error is not printed and the custom cost function is used.