### PR TITLE
Add option to keep optimizing after a valid solution was found

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -12,6 +12,7 @@ panda_arm:
   kinematics_solver_timeout: 0.05
   kinematics_solver_attempts: 3
   mode: global
+  stop_optimization_on_valid_solution: true
   rotation_scale: 0.5
   position_threshold: 0.001
   orientation_threshold: 0.01
@@ -31,6 +32,7 @@ For an exhaustive list of parameters, refer to the [parameters YAML file](../src
 Some key parameters you may want to start with are:
 
 * `mode`: If you choose `local`, this solver will only do local gradient descent; if you choose `global`, it will also enable the evolutionary algorithm. Using the global solver will be less performant, but if you're having trouble getting out of local minima, this could help you. We recommend using `local` for things like relative motion / Cartesian interpolation / endpoint jogging, and `global` if you need to solve for goals with a far-away initial conditions.
+* `stop_optimization_on_valid_solution`: The default mode of pick_ik is to give you the first valid solution (which satisfies all thresholds) to make IK calls quick. Set this parameter to true if you rather want to use your complete computational budget (based on `kinematics_solver_timeout` and the maximum number of iterations of the solvers) to try to find a solution with a low cost value.
 * `memetic_<property>`: All the properties that only kick in if you use the `global` solver. The key one is `memetic_num_threads`, as we have enabled the evolutionary algorithm to solve on multiple threads.
 * `cost_threshold`: This solver works by setting up cost functions based on how far away your pose is, how much your joints move relative to the initial guess, and custom cost functions you can add. Optimization succeeds only if the cost is less than `cost_threshold`. Note that if you're adding custom cost functions, you may want to set this threshold fairly high and rely on `position_threshold` and `orientation_threshold` to be your deciding factors, whereas this is more of a guideline.
 * `position_threshold`/`orientation_threshold`: Optimization succeeds only if the pose difference is less than these thresholds in meters and radians respectively. A `position_threshold` of 0.001 would mean a 1 mm accuracy and an `orientation_threshold` of 0.01 would mean a 0.01 radian accuracy.

--- a/include/pick_ik/ik_gradient.hpp
+++ b/include/pick_ik/ik_gradient.hpp
@@ -17,8 +17,8 @@ struct GradientIkParams {
     double min_cost_delta = 1.0e-12;  // Minimum cost difference for termination.
     double max_time = 0.05;           // Maximum time elapsed for termination.
     int max_iterations = 100;         // Maximum iterations for termination.
-    // If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached
-    // If false, stop thread on finding a valid solution
+    // If true, keeps running after finding a solution to further optimize the solution until a time
+    // or iteration limit is reached If false, stop thread on finding a valid solution
     bool optimize_solution = false;
 };
 

--- a/include/pick_ik/ik_gradient.hpp
+++ b/include/pick_ik/ik_gradient.hpp
@@ -17,9 +17,9 @@ struct GradientIkParams {
     double min_cost_delta = 1.0e-12;  // Minimum cost difference for termination.
     double max_time = 0.05;           // Maximum time elapsed for termination.
     int max_iterations = 100;         // Maximum iterations for termination.
-    // If true, keeps running after finding a solution to further optimize the solution until a time
-    // or iteration limit is reached. If false, stop thread on finding a valid solution.
-    bool optimize_solution = false;
+    // If false, keeps running after finding a solution to further optimize the solution until a
+    // time or iteration limit is reached. If true, stop thread on finding a valid solution.
+    bool stop_optimization_on_valid_solution = true;
 };
 
 struct GradientIk {

--- a/include/pick_ik/ik_gradient.hpp
+++ b/include/pick_ik/ik_gradient.hpp
@@ -17,6 +17,9 @@ struct GradientIkParams {
     double min_cost_delta = 1.0e-12;  // Minimum cost difference for termination.
     double max_time = 0.05;           // Maximum time elapsed for termination.
     int max_iterations = 100;         // Maximum iterations for termination.
+    // If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached
+    // If false, stop thread on finding a valid solution
+    bool optimize_solution = false;
 };
 
 struct GradientIk {

--- a/include/pick_ik/ik_gradient.hpp
+++ b/include/pick_ik/ik_gradient.hpp
@@ -18,7 +18,7 @@ struct GradientIkParams {
     double max_time = 0.05;           // Maximum time elapsed for termination.
     int max_iterations = 100;         // Maximum iterations for termination.
     // If true, keeps running after finding a solution to further optimize the solution until a time
-    // or iteration limit is reached If false, stop thread on finding a valid solution
+    // or iteration limit is reached. If false, stop thread on finding a valid solution.
     bool optimize_solution = false;
 };
 

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -33,6 +33,9 @@ struct MemeticIkParams {
     double max_time = 1.0;                 // Maximum time for evolutionary algorithm.
 
     size_t num_threads = 1;  // Number of species to solve in parallel.
+    // If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached
+    // If false, stop thread on finding a valid solution
+    bool optimize_solution = false;
     // If true, returns first solution and terminates other threads.
     // If false, waits for all threads to join and returns best solution.
     bool stop_on_first_soln = true;

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -33,9 +33,9 @@ struct MemeticIkParams {
     double max_time = 1.0;                 // Maximum time for evolutionary algorithm.
 
     size_t num_threads = 1;  // Number of species to solve in parallel.
-    // If true, keeps running after finding a solution to further optimize the solution until a time
-    // or iteration limit is reached. If false, stop thread on finding a valid solution.
-    bool optimize_solution = false;
+    // If false, keeps running after finding a solution to further optimize the solution until a
+    // time or iteration limit is reached. If true, stop thread on finding a valid solution.
+    bool stop_optimization_on_valid_solution = true;
     // If true, returns first solution and terminates other threads.
     // If false, waits for all threads to join and returns best solution.
     bool stop_on_first_soln = true;

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -34,7 +34,7 @@ struct MemeticIkParams {
 
     size_t num_threads = 1;  // Number of species to solve in parallel.
     // If true, keeps running after finding a solution to further optimize the solution until a time
-    // or iteration limit is reached If false, stop thread on finding a valid solution
+    // or iteration limit is reached. If false, stop thread on finding a valid solution.
     bool optimize_solution = false;
     // If true, returns first solution and terminates other threads.
     // If false, waits for all threads to join and returns best solution.

--- a/include/pick_ik/ik_memetic.hpp
+++ b/include/pick_ik/ik_memetic.hpp
@@ -33,8 +33,8 @@ struct MemeticIkParams {
     double max_time = 1.0;                 // Maximum time for evolutionary algorithm.
 
     size_t num_threads = 1;  // Number of species to solve in parallel.
-    // If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached
-    // If false, stop thread on finding a valid solution
+    // If true, keeps running after finding a solution to further optimize the solution until a time
+    // or iteration limit is reached If false, stop thread on finding a valid solution
     bool optimize_solution = false;
     // If true, returns first solution and terminates other threads.
     // If false, waits for all threads to join and returns best solution.

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -102,7 +102,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
                  SolutionTestFn const& solution_fn,
                  GradientIkParams const& params,
                  bool approx_solution) -> std::optional<std::vector<double>> {
-    if (solution_fn(initial_guess)) {
+    if (!params.optimize_solution && solution_fn(initial_guess)) {
         return initial_guess;
     }
 
@@ -118,7 +118,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
     while ((std::chrono::system_clock::now() < timeout_point) &&
            (num_iterations < params.max_iterations)) {
         if (step(ik, robot, cost_fn, params.step_size)) {
-            if (solution_fn(ik.best)) {
+            if (!params.optimize_solution && solution_fn(ik.best)) {
                 return ik.best;
             }
         }
@@ -128,6 +128,10 @@ auto ik_gradient(std::vector<double> const& initial_guess,
         }
         previous_cost = ik.local_cost;
         num_iterations++;
+    }
+
+    if(params.optimize_solution && solution_fn(ik.best)){
+        return ik.best;
     }
 
     // If no solution was found, either return the approximate solution or nothing.

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -102,7 +102,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
                  SolutionTestFn const& solution_fn,
                  GradientIkParams const& params,
                  bool approx_solution) -> std::optional<std::vector<double>> {
-    if (!params.optimize_solution && solution_fn(initial_guess)) {
+    if (params.stop_optimization_on_valid_solution && solution_fn(initial_guess)) {
         return initial_guess;
     }
 
@@ -118,7 +118,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
     while ((std::chrono::system_clock::now() < timeout_point) &&
            (num_iterations < params.max_iterations)) {
         if (step(ik, robot, cost_fn, params.step_size)) {
-            if (!params.optimize_solution && solution_fn(ik.best)) {
+            if (params.stop_optimization_on_valid_solution && solution_fn(ik.best)) {
                 return ik.best;
             }
         }
@@ -130,7 +130,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
         num_iterations++;
     }
 
-    if (params.optimize_solution && solution_fn(ik.best)) {
+    if (!params.stop_optimization_on_valid_solution && solution_fn(ik.best)) {
         return ik.best;
     }
 

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -130,7 +130,7 @@ auto ik_gradient(std::vector<double> const& initial_guess,
         num_iterations++;
     }
 
-    if(params.optimize_solution && solution_fn(ik.best)){
+    if (params.optimize_solution && solution_fn(ik.best)) {
         return ik.best;
     }
 

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -244,7 +244,7 @@ auto ik_memetic_impl(std::vector<double> const& initial_guess,
         }
 
         // Check for termination and wipeout conditions
-        if (solution_fn(ik.best().genes)) {
+        if (!params.optimize_solution && solution_fn(ik.best().genes)) {
             if (print_debug) fmt::print("Found solution!\n");
             return ik.best();
         }
@@ -260,6 +260,12 @@ auto ik_memetic_impl(std::vector<double> const& initial_guess,
         }
 
         iter++;
+    }
+
+    // If we kept optimizing, we need to check if we found a valid solution
+    if (params.optimize_solution && solution_fn(ik.best().genes)) {
+        if (print_debug) fmt::print("Found solution!\n");
+        return ik.best();
     }
 
     if (approx_solution) {
@@ -279,7 +285,7 @@ auto ik_memetic(std::vector<double> const& initial_guess,
                 bool print_debug) -> std::optional<std::vector<double>> {
     // Check whether the initial guess already meets the goal,
     // before starting to solve.
-    if (solution_fn(initial_guess)) {
+    if (!params.optimize_solution && solution_fn(initial_guess)) {
         return initial_guess;
     }
 

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -244,7 +244,7 @@ auto ik_memetic_impl(std::vector<double> const& initial_guess,
         }
 
         // Check for termination and wipeout conditions
-        if (!params.optimize_solution && solution_fn(ik.best().genes)) {
+        if (params.stop_optimization_on_valid_solution && solution_fn(ik.best().genes)) {
             if (print_debug) fmt::print("Found solution!\n");
             return ik.best();
         }
@@ -263,7 +263,7 @@ auto ik_memetic_impl(std::vector<double> const& initial_guess,
     }
 
     // If we kept optimizing, we need to check if we found a valid solution
-    if (params.optimize_solution && solution_fn(ik.best().genes)) {
+    if (!params.stop_optimization_on_valid_solution && solution_fn(ik.best().genes)) {
         if (print_debug) fmt::print("Found solution!\n");
         return ik.best();
     }
@@ -285,7 +285,7 @@ auto ik_memetic(std::vector<double> const& initial_guess,
                 bool print_debug) -> std::optional<std::vector<double>> {
     // Check whether the initial guess already meets the goal,
     // before starting to solve.
-    if (!params.optimize_solution && solution_fn(initial_guess)) {
+    if (params.stop_optimization_on_valid_solution && solution_fn(initial_guess)) {
         return initial_guess;
     }
 

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -113,10 +113,10 @@ pick_ik:
       gt_eq<>: [0.0],
     },
   }
-  optimize_solution: {
+  stop_optimization_on_valid_solution : {
     type: bool,
-    default_value: false,
-    description: "If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached",
+    default_value: true,
+    description: "If false, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached",
   }
   # Memetic IK specific parameters
   memetic_num_threads: {

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -113,6 +113,11 @@ pick_ik:
       gt_eq<>: [0.0],
     },
   }
+  optimize_solution: {
+    type: bool,
+    default_value: false,
+    description: "If true, keeps running after finding a solution to further optimize the solution until a time or iteration limit is reached",
+  }
   # Memetic IK specific parameters
   memetic_num_threads: {
     type: int,

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -166,7 +166,8 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             ik_params.population_size = static_cast<size_t>(params.memetic_population_size);
             ik_params.elite_size = static_cast<size_t>(params.memetic_elite_size);
             ik_params.wipeout_fitness_tol = params.memetic_wipeout_fitness_tol;
-            ik_params.optimize_solution = params.optimize_solution;
+            ik_params.stop_optimization_on_valid_solution =
+                params.stop_optimization_on_valid_solution;
             ik_params.num_threads = static_cast<size_t>(params.memetic_num_threads);
             ik_params.stop_on_first_soln = params.memetic_stop_on_first_solution;
             ik_params.max_generations = static_cast<int>(params.memetic_max_generations);
@@ -190,7 +191,8 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             gd_params.min_cost_delta = params.gd_min_cost_delta;
             gd_params.max_time = timeout;
             gd_params.max_iterations = static_cast<int>(params.gd_max_iters);
-            gd_params.optimize_solution = params.optimize_solution;
+            gd_params.stop_optimization_on_valid_solution =
+                params.stop_optimization_on_valid_solution;
 
             maybe_solution = ik_gradient(ik_seed_state,
                                          robot_,

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -166,6 +166,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             ik_params.population_size = static_cast<size_t>(params.memetic_population_size);
             ik_params.elite_size = static_cast<size_t>(params.memetic_elite_size);
             ik_params.wipeout_fitness_tol = params.memetic_wipeout_fitness_tol;
+            ik_params.optimize_solution = params.optimize_solution;
             ik_params.num_threads = static_cast<size_t>(params.memetic_num_threads);
             ik_params.stop_on_first_soln = params.memetic_stop_on_first_solution;
             ik_params.max_generations = static_cast<int>(params.memetic_max_generations);
@@ -189,6 +190,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             gd_params.min_cost_delta = params.gd_min_cost_delta;
             gd_params.max_time = timeout;
             gd_params.max_iterations = static_cast<int>(params.gd_max_iters);
+            gd_params.optimize_solution = params.optimize_solution;
 
             maybe_solution = ik_gradient(ik_seed_state,
                                          robot_,


### PR DESCRIPTION
Currently, pick_ik will try to find an IK solution that optimizes for the given goal pose and the additional goals. As soon as the current best solution satisfies the pose threshold and the cost threshold, it will return the solution.
https://github.com/PickNikRobotics/pick_ik/blob/807b04e47a33452032d161933236843d3f11566d/src/ik_memetic.cpp#L247-L249
This makes sense in a lot of applications, as you often want to get a (for your context) valid IK solution as fast as possible. However, there are also scenarios where you are not in a hurry and might want to keep optimizing the IK solution until you reach a certain time or iteration limit. 
This is currently not easily possible in pick_ik. It is possible to reduce the cost_threshold, so that the optimization runs longer. However, this comes with the risk that no solution is acepted as correct.
I first thought that the `memetic_stop_on_first_solution` would do this, but it only regards the stopping of other threads as soon as one has found a solution.
Therefore, I added the `optimize_solution` option which will keep optimizing the solution till either time or iteration limit is reached. Indpependend on the usage of threads and IK mode.

If you don't want to merge this upstream it is, of course, also fine.