### PR TITLE
Fix not using result of solution callback

### DIFF
--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -266,7 +266,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             solution_callback(ik_poses.front(), solution, error_code);
         }
 
-        return found_solution;
+        return error_code.val == error_code.SUCCESS;
     }
 
     virtual std::vector<std::string> const& getJointNames() const { return joint_names_; }


### PR DESCRIPTION
This PR fixes a small bug introduced in https://github.com/PickNikRobotics/pick_ik/pull/42 due to which the result of the solution callback was ignored. Therefore, the `GroupStateValidityCallbackFn` (which is often used for collision checking) in the `setFromIK()` call was ignored.

Independent from this error, I was also wondering if the current way to call this function makes sense. Currently, it is only called at the very end of `searchPositionIK()`. This means, during the process of searching for an IK solution, pick_ik constantly checks the `solution_fn` (which does not contain the callback). When this finally returns `true`, it will check the callback. If the callback then returns `false`, pick_ik will say that it did not find a valid solution, although neither time nor iteration limits have been reached. Instead it would also be possible to continue searching for a solution until either a limit has reached or the `solution_fn` and the callback are valid at the same time.
I saw that bio_ik was doing it also like pick_ik is doing it currently. Maybe it is how MoveIt expects the kinematics_plugins to behave. However, I think that there might be benefit in changing this behavior, so that a valid solution is found more often.