### PR TITLE
Add approximate solution cost threshold parameter

### DIFF
--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -57,5 +57,6 @@ ros2 param set /rviz2 robot_description_kinematics.panda_arm.minimal_displacemen
 The [kinematics plugin](../src/pick_ik_plugin.cpp) allows you to pass in an additional argument of type `IkCostFn`, which can be passed in from common entrypoints such as `RobotState::setFromIK()`. See [this page](https://moveit.picknik.ai/humble/doc/examples/robot_model_and_robot_state/robot_model_and_robot_state_tutorial.html?highlight=setfromik#inverse-kinematics) for a usage example.
 Keep in mind that you need to set `position_scale = 0.0` and `rotation_scale = 0.0` if you want to calculate the costs solely based on your `IkCostFn`.
 If these parameters are non-zero, the target pose will still be part of the overall cost function.
+Additionally, you might want to define values for the `cost_threshold`, `approximate_solution_cost_threshold`, and `stop_optimization_on_valid_solution` parameters to decide when pick_ik will stop optimizing for your cost function and which solutions it should accept.
 
 Alternatively, consider adding your own cost functions to the `pick_ik` source code (specifically, in [`goal.hpp`](../include/goal.hpp) and [`goal.cpp`](../src/goal.cpp) and submit a pull request with the new functionality you add.

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -76,7 +76,7 @@ pick_ik:
   approximate_solution_cost_threshold: {
     type: double,
     default_value: 0.0,
-    description: "Cost threshold for approximate IK solutions. If the result of the cost function is larger than this, the approximate solution will fall back to the initial guess",
+    description: "Cost threshold for approximate IK solutions. If the result of the cost function is larger than this, the approximate solution will fall back to the initial guess.",
     validation: {
       gt_eq<>: [0.0],
     },

--- a/src/pick_ik_parameters.yaml
+++ b/src/pick_ik_parameters.yaml
@@ -73,6 +73,14 @@ pick_ik:
       gt_eq<>: [0.0],
     },
   }
+  approximate_solution_cost_threshold: {
+    type: double,
+    default_value: 0.0,
+    description: "Cost threshold for approximate IK solutions. If the result of the cost function is larger than this, the approximate solution will fall back to the initial guess",
+    validation: {
+      gt_eq<>: [0.0],
+    },
+  }
   cost_threshold: {
     type: double,
     default_value: 0.001,

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -246,7 +246,10 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             }
 
             auto const approx_solution_fn =
-                make_is_solution_test_fn(frame_tests, goals, params.approximate_solution_cost_threshold, fk_fn);
+                make_is_solution_test_fn(frame_tests,
+                                         goals,
+                                         params.approximate_solution_cost_threshold,
+                                         fk_fn);
 
             bool approx_solution_valid = approx_solution_fn(solution);
 

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -239,14 +239,16 @@ class PickIKPlugin : public kinematics::KinematicsBase {
                 make_frame_tests(goal_frames,
                                  approximate_solution_position_threshold,
                                  approximate_solution_orientation_threshold);
-            auto const tip_frames = fk_fn(solution);
-            bool approx_solution_valid = true;
-            for (size_t i = 0; i < approx_frame_tests.size(); ++i) {
-                if (!approx_frame_tests[i](tip_frames[i])) {
-                    approx_solution_valid = false;
-                    break;
-                }
+
+            // If we have no cost threshold, we don't need to check the goals
+            if (params.approximate_solution_cost_threshold <= 0.0) {
+                goals.clear();
             }
+
+            auto const approx_solution_fn =
+                make_is_solution_test_fn(frame_tests, goals, params.approximate_solution_cost_threshold, fk_fn);
+
+            bool approx_solution_valid = approx_solution_fn(solution);
 
             // Check joint thresholds
             if (approx_solution_valid && params.approximate_solution_joint_threshold > 0.0) {


### PR DESCRIPTION
This PR adds a cost threshold parameter for the approximate solution.
The motivation for this is, that it gives the same threshold options for the approximate goal as for the exact goal. Thereby, the user can decide in more detail which approximate solution they want to accept.
I use it, for example, so that I can stop optimizing if a goal reaches a certain threshold (the `cost_threshold`) but if I did not manage to find this, I will still accept a goal which has a higher cost value as long as it is not too high (below the `approximate_solution_cost_threshold`).

I also changed the code a bit to use gain the `make_is_solution_test_fn()`. Before, there was a bit of code duplication which would have gotten worse with the addition of my parameter.