### PR TITLE
Switch from `std::set` to `std::vector` to prevent joint name alphabetization

### DIFF
--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -99,11 +99,11 @@ auto get_active_variable_indices(std::shared_ptr<moveit::core::RobotModel const>
     // For each of the active joints in the joint model group
     // If those are in the ones we are using and the joint is not a mimic
     // Then get all the variable names from the joint moodel
-    auto active_variable_names = std::set<std::string>{};
+    auto active_variable_names = std::vector<std::string>{};
     for (auto const* joint_model : jmg->getActiveJointModels()) {
         if (joint_usage[joint_model->getJointIndex()] && !joint_model->getMimic()) {
             for (auto& name : joint_model->getVariableNames()) {
-                active_variable_names.insert(name);
+                active_variable_names.push_back(name);
             }
         }
     }


### PR DESCRIPTION
After some debugging, we found an issue in which joint names are being alphabetized because of the use of a `std::set`... this didn't manifest itself in all the models we've tested with so far because often joint names are numbered by their order in a kinematic chain.

See https://github.com/PickNikRobotics/pick_ik/issues/43#issuecomment-1605543570 for more details.

Closes https://github.com/PickNikRobotics/pick_ik/issues/43