### PR TITLE
Support continuous (unbounded) joints properly

### DIFF
--- a/include/pick_ik/robot.hpp
+++ b/include/pick_ik/robot.hpp
@@ -13,17 +13,27 @@ namespace pick_ik {
 
 struct Robot {
     struct Variable {
-        /// @brief Min and max position values of the variable.
-        double min, max;
+        /// @brief Min, max, and middle position values of the variable.
+        double min, max, mid;
 
         /// @brief Whether the variable's position is bounded.
         bool bounded;
 
-        /// @brief The span (min - max) of the variable, or a default value if unbounded.
-        double span;
+        /// @brief The half-span (min - max) / 2.0 of the variable, or a default value if unbounded.
+        double half_span;
 
         double max_velocity_rcp;
         double minimal_displacement_factor;
+
+        /// @brief Generates a valid variable value given an optional initial value (for unbounded
+        /// joints).
+        auto generate_valid_value(double init_val = 0.0) const -> double;
+
+        /// @brief Returns true if a value is valid given the variable bounds.
+        auto is_valid(double val) const -> bool;
+
+        /// @brief Clamps a configuration to joint limits.
+        auto clamp_to_limits(double val) const -> double;
     };
     std::vector<Variable> variables;
 
@@ -32,7 +42,10 @@ struct Robot {
                      moveit::core::JointModelGroup const* jmg,
                      std::vector<size_t> tip_link_indices) -> Robot;
 
-    /** @brief Sets a variable vector to a random valid configuration. */
+    /**
+     * @brief Sets a variable vector to a random configuration.
+     * @details Here, "valid" denotes that the joint values are with their specified limits.
+     */
     auto set_random_valid_configuration(std::vector<double>& config) const -> void;
 
     /** @brief Check is a configuration is valid. */

--- a/include/pick_ik/robot.hpp
+++ b/include/pick_ik/robot.hpp
@@ -13,10 +13,15 @@ namespace pick_ik {
 
 struct Robot {
     struct Variable {
-        double clip_min, clip_max;
+        /// @brief Min and max position values of the variable.
+        double min, max;
+
+        /// @brief Whether the variable's position is bounded.
+        bool bounded;
+
+        /// @brief The span (min - max) of the variable, or a default value if unbounded.
         double span;
-        double min;
-        double max;
+
         double max_velocity_rcp;
         double minimal_displacement_factor;
     };
@@ -27,8 +32,8 @@ struct Robot {
                      moveit::core::JointModelGroup const* jmg,
                      std::vector<size_t> tip_link_indices) -> Robot;
 
-    /** @brief Returns a random valid configuration. */
-    auto get_random_valid_configuration() const -> std::vector<double>;
+    /** @brief Sets a variable vector to a random valid configuration. */
+    auto set_random_valid_configuration(std::vector<double>& config) const -> void;
 
     /** @brief Check is a configuration is valid. */
     auto is_valid_configuration(std::vector<double> const& config) const -> bool;

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -119,10 +119,10 @@ auto make_avoid_joint_limits_cost_fn(Robot robot) -> CostFn {
 
             auto const position = active_positions[i];
             auto const weight = variable.minimal_displacement_factor;
-            auto const mid = (variable.min + variable.max) * 0.5;
-            auto const span = variable.span;
-            sum +=
-                std::pow(std::fmax(0.0, std::fabs(position - mid) * 2.0 - span * 0.5) * weight, 2);
+            sum += std::pow(
+                std::fmax(0.0, std::fabs(position - variable.mid) * 2.0 - variable.half_span) *
+                    weight,
+                2);
         }
         return sum;
     };

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -94,7 +94,7 @@ auto make_center_joints_cost_fn(Robot robot) -> CostFn {
         assert(robot.variables.size() == active_positions.size());
         for (size_t i = 0; i < active_positions.size(); ++i) {
             auto const& variable = robot.variables[i];
-            if (variable.clip_max == std::numeric_limits<double>::max()) {
+            if (!variable.bounded) {
                 continue;
             }
 
@@ -113,7 +113,7 @@ auto make_avoid_joint_limits_cost_fn(Robot robot) -> CostFn {
         assert(robot.variables.size() == active_positions.size());
         for (size_t i = 0; i < active_positions.size(); ++i) {
             auto const& variable = robot.variables[i];
-            if (variable.clip_max == std::numeric_limits<double>::max()) {
+            if (!variable.bounded) {
                 continue;
             }
 

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -78,9 +78,11 @@ auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double st
     // apply optimization step
     // (move along gradient direction by estimated step size)
     for (size_t i = 0; i < count; ++i) {
-        self.working[i] = std::clamp(self.local[i] - self.gradient[i] * joint_diff,
-                                     robot.variables[i].clip_min,
-                                     robot.variables[i].clip_max);
+        auto const& var = robot.variables[i];
+        if (var.bounded) {
+            self.working[i] =
+                std::clamp(self.local[i] - self.gradient[i] * joint_diff, var.min, var.max);
+        }
     }
 
     // Always accept the solution and continue

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -25,7 +25,6 @@ auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double st
     auto const count = self.local.size();
 
     // compute gradient direction
-    self.working = self.local;
     for (size_t i = 0; i < count; ++i) {
         // test negative displacement
         self.working[i] = self.local[i] - step_size;
@@ -55,8 +54,6 @@ auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double st
                    [&](auto value) { return value * f; });
 
     // initialize line search
-    self.working = self.local;
-
     for (size_t i = 0; i < count; ++i) {
         self.working[i] = self.local[i] - self.gradient[i];
     }

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -77,13 +77,7 @@ auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double st
     for (size_t i = 0; i < count; ++i) {
         auto const& var = robot.variables[i];
         auto updated_value = self.local[i] - self.gradient[i] * joint_diff;
-        if (var.bounded) {
-            self.working[i] = std::clamp(updated_value, var.min, var.max);
-        } else {
-            self.working[i] = std::clamp(updated_value,
-                                         self.local[i] - var.span / 2.0,
-                                         self.local[i] + var.span / 2.0);
-        }
+        self.working[i] = var.clamp_to_limits(updated_value);
     }
 
     // Always accept the solution and continue

--- a/src/ik_gradient.cpp
+++ b/src/ik_gradient.cpp
@@ -79,9 +79,13 @@ auto step(GradientIk& self, Robot const& robot, CostFn const& cost_fn, double st
     // (move along gradient direction by estimated step size)
     for (size_t i = 0; i < count; ++i) {
         auto const& var = robot.variables[i];
+        auto updated_value = self.local[i] - self.gradient[i] * joint_diff;
         if (var.bounded) {
-            self.working[i] =
-                std::clamp(self.local[i] - self.gradient[i] * joint_diff, var.min, var.max);
+            self.working[i] = std::clamp(updated_value, var.min, var.max);
+        } else {
+            self.working[i] = std::clamp(updated_value,
+                                         self.local[i] - var.span / 2.0,
+                                         self.local[i] + var.span / 2.0);
         }
     }
 

--- a/src/ik_memetic.cpp
+++ b/src/ik_memetic.cpp
@@ -158,6 +158,10 @@ void MemeticIk::reproduce(Robot const& robot, CostFn const& cost_fn) {
                 // Clamp to valid joint values
                 if (joint.bounded) {
                     gene = std::clamp(gene, joint.min, joint.max);
+                } else {
+                    gene = std::clamp(gene,
+                                      original_gene - joint.span / 2.0,
+                                      original_gene + joint.span / 2.0);
                 }
 
                 // Approximate gradient

--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -179,7 +179,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             RCLCPP_WARN(
                 LOGGER,
                 "Initial guess exceeds joint limits. Regenerating a random valid configuration.");
-            init_state = robot_.get_random_valid_configuration();
+            robot_.set_random_valid_configuration(init_state);
         }
 
         // Optimize until a valid solution is found or we have timed out.
@@ -309,13 +309,9 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             if (found_valid_solution || timeout_elapsed) {
                 done_optimizing = true;
             } else {
-                init_state = robot_.get_random_valid_configuration();
+                robot_.set_random_valid_configuration(init_state);
                 remaining_timeout -= total_optim_time.count();
             }
-        }
-
-        if (!robot_.is_valid_configuration(solution)) {
-            std::cout << "INVALID SOLUTION!" << std::endl;
         }
 
         return found_valid_solution;

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -14,11 +14,32 @@
 #include <moveit/robot_state/robot_state.h>
 
 namespace {
-constexpr double kUnboundedVariableSpan = 2.0 * M_PI;
+constexpr double kUnboundedVariableHalfSpan = M_PI;
 constexpr double kUnboundedJointSampleSpread = M_PI;
 }  // namespace
 
 namespace pick_ik {
+
+auto Robot::Variable::generate_valid_value(double init_val /* = 0.0*/) const -> double {
+    if (bounded) {
+        return rsl::uniform_real(min, max);
+    } else {
+        return rsl::uniform_real(init_val - kUnboundedJointSampleSpread,
+                                 init_val + kUnboundedJointSampleSpread);
+    }
+}
+
+auto Robot::Variable::is_valid(double val) const -> bool {
+    return (!bounded) || (val <= max && val >= min);
+}
+
+auto Robot::Variable::clamp_to_limits(double val) const -> double {
+    if (bounded) {
+        return std::clamp(val, min, max);
+    } else {
+        return std::clamp(val, val - half_span, val + half_span);
+    }
+}
 
 auto Robot::from(std::shared_ptr<moveit::core::RobotModel const> const& model,
                  moveit::core::JointModelGroup const* jmg,
@@ -41,8 +62,8 @@ auto Robot::from(std::shared_ptr<moveit::core::RobotModel const> const& model,
         var.bounded = bounds.position_bounded_;
         var.min = bounds.min_position_;
         var.max = bounds.max_position_;
-
-        var.span = var.bounded ? var.max - var.min : kUnboundedVariableSpan;
+        var.mid = 0.5 * (var.min + var.max);
+        var.half_span = var.bounded ? (var.max - var.min) / 2.0 : kUnboundedVariableHalfSpan;
 
         auto const max_velocity = bounds.max_velocity_;
         var.max_velocity_rcp = max_velocity > 0.0 ? 1.0 / max_velocity : 0.0;
@@ -69,24 +90,14 @@ auto Robot::set_random_valid_configuration(std::vector<double>& config) const ->
         config.resize(num_vars);
     }
     for (size_t idx = 0; idx < num_vars; ++idx) {
-        auto const& var = variables[idx];
-        if (var.bounded) {
-            config[idx] = rsl::uniform_real(var.min, var.max);
-        } else {
-            config[idx] = rsl::uniform_real(config[idx] - kUnboundedJointSampleSpread,
-                                            config[idx] + kUnboundedJointSampleSpread);
-        }
+        config[idx] = variables[idx].generate_valid_value(config[idx]);
     }
 }
 
 auto Robot::is_valid_configuration(std::vector<double> const& config) const -> bool {
     auto const num_vars = variables.size();
     for (size_t idx = 0; idx < num_vars; ++idx) {
-        auto const var = variables[idx];
-        if (!var.bounded) {
-            continue;
-        }
-        if (config[idx] > var.max || config[idx] < var.min) {
+        if (!variables[idx].is_valid(config[idx])) {
             return false;
         }
     }

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -14,7 +14,7 @@
 #include <moveit/robot_state/robot_state.h>
 
 namespace {
-constexpr double kUnboundedVariableSpan = 1.0;
+constexpr double kUnboundedVariableSpan = 2.0 * M_PI;
 constexpr double kUnboundedJointSampleSpread = M_PI;
 }  // namespace
 


### PR DESCRIPTION
This PR correctly handles how to deal with continuous joints by ensuring that none of the RSL samples use the full floating-point span. Also did some slight cleanup along the way.

The key here is that, if a joint is continuous, our sampling now is casting a "spread" of +/- pi radians around the *current state*. That way the sampling is somewhat limited.

Closes https://github.com/PickNikRobotics/pick_ik/issues/57