### PR TITLE
Do not override `tip_frames`

### DIFF
--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -71,13 +71,6 @@ class PickIKPlugin : public kinematics::KinematicsBase {
             }
         }
 
-        // If jmg has tip frames, set tip_frames_ to jmg tip frames
-        // consider removing these lines as they might be unnecessary
-        // as tip_frames_ is set by the call to storeValues above
-        auto jmg_tips = std::vector<std::string>{};
-        jmg_->getEndEffectorTips(jmg_tips);
-        if (!jmg_tips.empty()) tip_frames_ = jmg_tips;
-
         // link_names are the same as tip frames
         // TODO: why do we need to set this
         link_names_ = tip_frames_;


### PR DESCRIPTION
# Description

The MoveIt2 plugin structure is designed such that the correct tip frame(s) are passed into the `initialize` function, and consequently stored in `tip_frames_` by `storeValues(…)`. However, Pick IK overrides those `tip_frames_` with the joint model group's tip frames. There are two downsides to this:
1. **It is unexpected**. None of the commonly used MoveIt2 kinematics solvers override `tip_frames_` (e.g., [KDLKinematicsPlugin](https://github.com/ros-planning/moveit2/blob/43c5f6d03e423b53afa3a27f659adf2e6c3f4b5b/moveit_kinematics/kdl_kinematics_plugin/src/kdl_kinematics_plugin.cpp#L132), [Bio IK](https://github.com/TAMS-Group/bio_ik/blob/cca0f2ba9c2333962d1d429633f4557607e27ed6/src/kinematics_plugin.cpp#L368)). This hinders the ability for kinematics plugins to directly replace one another.
2. **It is incorrect**: The tips returned by the joint model group's `getEndEffectorTips` are those **_groups_** that are specified as end-effectors in the SRDF (using the [SRDF `end_effector` tag](https://moveit.picknik.ai/humble/doc/examples/urdf_srdf/urdf_srdf_tutorial.html#end-effectors)). This is not necessarily the same as the **_link_** that is specified as the tip of a group in the SRDF. Typically, a group that we would want to do IK for has a single tip specified in the SRDF (i.e., using the `chain` tag). However, such a group could have _multiple_ other groups specified as end effectors (as mentioned in [MoveIt's docstring for `getEndEffectorTips`](https://github.com/ros-planning/moveit2/blob/43c5f6d03e423b53afa3a27f659adf2e6c3f4b5b/moveit_core/robot_model/include/moveit/robot_model/joint_model_group.h#L496)). Alternatively, even if a parent group has only one group specified as its end effector, that end effector group is not necessarily mounted at the tip of the parent group. In either of the above circumstances, `getEndEffectorTips(...)` will return a different list from the `tip_frames` that are passed into the kinematics plugin.

This PR addresses the above issue by removing Pick IK's overriding of `tip_frames_`.

# Testing

I tested this in two ways:

1. Ran the unit tests (i.e., `colcon test --packages-select pick_ik --ctest-args tests`) and verified that no tests failed, encountered errors, or were skipped.
2. For our robot (Kinova JACO Gen2 arm with end-effector modifications), I verified that Pick IK stores the correct tip in `tip_frames_`, and behaves as expected.