### PR TITLE
Fix timeout calculation if solution callback fails

### DIFF
--- a/src/pick_ik_plugin.cpp
+++ b/src/pick_ik_plugin.cpp
@@ -310,7 +310,7 @@ class PickIKPlugin : public kinematics::KinematicsBase {
                 done_optimizing = true;
             } else {
                 robot_.set_random_valid_configuration(init_state);
-                remaining_timeout -= total_optim_time.count();
+                remaining_timeout = timeout - total_optim_time.count();
             }
         }
 


### PR DESCRIPTION
Currently, the remaining timeout is recalculated after a solution callback fails by subtracting the total time since the start from the current remaining timeout. This is wrong in all iterations except the first, instead, the total time since the start should be subtracted from the initial timeout.
The current behavior is that pick_ik runs for the whole time available but after some time (in my case around 140ms) the remaining timeout is negative and the while loop in https://github.com/PickNikRobotics/pick_ik/blob/87b4c60563b9d87c5de5c0336da32b3f99836bfa/src/ik_memetic.cpp#L228 immediately exits, making it impossible to find more solutions.